### PR TITLE
Bugfix sorting in project names separates upper and lowercase

### DIFF
--- a/managers/factories.py
+++ b/managers/factories.py
@@ -1,0 +1,13 @@
+import factory
+import factory.fuzzy
+
+from managers.models import Project
+
+
+class ProjectFactory(factory.DjangoModelFactory):
+
+    class Meta:
+        model = Project
+
+    name = factory.Faker('sentence', nb_words=3)
+    start_date = factory.Faker('date')

--- a/managers/tests/test_api.py
+++ b/managers/tests/test_api.py
@@ -1,0 +1,74 @@
+from rest_framework.reverse import reverse
+from django.shortcuts import reverse
+
+from django.test import TestCase
+
+from managers.factories import ProjectFactory
+from users.models import CustomUser
+
+
+class ProjectsListTests(TestCase):
+
+    def setUp(self):
+        self.url = reverse('project-list')
+        self.user = CustomUser.objects._create_user(
+            "testuser@codepoets.it",
+            "testuserpasswd",
+            False,
+            False,
+            CustomUser.UserType.MANAGER.name,
+        )
+
+    def test_project_list_view_should_display_project_list_ordered_by_name(self):
+        project_1 = ProjectFactory(name='Bc')
+        project_2 = ProjectFactory(name='Zx')
+        project_3 = ProjectFactory(name='Ab')
+
+        expected_project_order = [
+            project_3.name, project_1.name, project_2.name
+        ]
+
+        self.client.force_login(user=self.user)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [project['name'] for project in response.data],
+            expected_project_order,
+        )
+
+    def test_project_list_view_should_display_project_list_ordered_by_name_case_insensitive(self):
+        project_1 = ProjectFactory(name='Bc')
+        project_2 = ProjectFactory(name='Zx')
+        project_3 = ProjectFactory(name='ab')
+
+        expected_project_order = [
+            project_3.name, project_1.name, project_2.name
+        ]
+
+        self.client.force_login(user=self.user)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [project['name'] for project in response.data],
+            expected_project_order,
+        )
+
+    def test_project_list_view_should_display_project_list_ordered_by_name_regardless_case(self):
+        project_1 = ProjectFactory(name='Bc')
+        project_2 = ProjectFactory(name='Az')
+        project_3 = ProjectFactory(name='ab')
+
+        expected_project_order = [
+            project_3.name, project_2.name, project_1.name
+        ]
+
+        self.client.force_login(user=self.user)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [project['name'] for project in response.data],
+            expected_project_order,
+        )

--- a/managers/urls.py
+++ b/managers/urls.py
@@ -1,11 +1,12 @@
-from django.urls import include, path
+from django.conf.urls import url
+from django.urls import include
 from rest_framework import routers
 from managers import views
 
 
 router = routers.DefaultRouter()
-router.register(r'projects', views.ProjectViewSet)
+router.register(r'projects', views.ProjectViewSet, 'project')
 
 urlpatterns = [
-    path('', include(router.urls)),
+    url('^', include(router.urls)),
 ]

--- a/managers/views.py
+++ b/managers/views.py
@@ -1,8 +1,9 @@
+from django.db.models.functions import Lower
 from rest_framework import viewsets
 from managers.models import Project
 from managers.serializers import ProjectSerializer
 
 
 class ProjectViewSet(viewsets.ModelViewSet):
-    queryset = Project.objects.all()
+    queryset = Project.objects.all().order_by(Lower('name'))
     serializer_class = ProjectSerializer

--- a/requirements.lock
+++ b/requirements.lock
@@ -10,6 +10,7 @@ django-countries==5.3.2
 django-mock-queries==2.1.1
 django-rest-auth==0.9.3
 djangorestframework==3.8.2
+factory-boy==2.11.1
 flake8==3.7.5
 freezegun==0.3.11
 idna==2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ django-allauth
 django-mock-queries
 django-rest-auth
 djangorestframework
+factory-boy
 freezegun
 idna
 oauthlib


### PR DESCRIPTION
Resolves https://github.com/Code-Poets/sheetstorm/issues/69