### PR TITLE
Fix django warnings about renamed `psycopg2`

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -11,10 +11,14 @@ django-markdown-deux==1.0.5
 django-mock-queries==2.1.1
 django-rest-auth==0.9.3
 djangorestframework==3.8.2
+entrypoints==0.3
 factory-boy==2.11.1
+Faker==1.0.4
 flake8==3.7.5
 freezegun==0.3.11
 idna==2.7
+markdown2==2.3.7
+mccabe==0.6.1
 mock==2.0.0
 model-mommy==1.6.0
 more-itertools==5.0.0
@@ -22,7 +26,10 @@ oauthlib==2.1.0
 pbr==5.1.2
 pluggy==0.8.1
 psycopg2==2.7.5
+psycopg2-binary==2.7.7
 py==1.7.0
+pycodestyle==2.5.0
+pyflakes==2.1.1
 pytest==4.1.1
 pytest-cov==2.6.1
 pytest-django==3.4.5
@@ -33,4 +40,5 @@ PyYAML==3.13
 requests==2.19.1
 requests-oauthlib==1.0.0
 six==1.11.0
+text-unidecode==1.2
 urllib3==1.23


### PR DESCRIPTION
There is no issue for that