### PR TITLE
Move javascript related imports in base.html before block content

### DIFF
--- a/users/templates/base.html
+++ b/users/templates/base.html
@@ -10,6 +10,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="{% static 'users/center_style.css' %}" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
     {% block extra_head %}{% endblock %}
 </head>
 <body>
@@ -52,8 +54,5 @@
     {% endblock %}
 </div>
   </main>
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
-  {% block extra_script %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
Fixes issues regarding javascript functions crashing on page render.

Resolves #126 