### PR TITLE
Bugfix repair handlers for admin in handlers

### DIFF
--- a/managers/models.py
+++ b/managers/models.py
@@ -53,7 +53,7 @@ def update_user_type(sender: Project, action: str, pk_set: Set, **kwargs: Any) -
 
 def change_user_type_to_manager(project: Project) -> None:
     for manager in project.managers.all():
-        if manager.user_type != CustomUser.UserType.MANAGER.name:
+        if manager.user_type == CustomUser.UserType.EMPLOYEE.name:
             manager.user_type = CustomUser.UserType.MANAGER.name
             manager.full_clean()
             manager.save()
@@ -64,7 +64,7 @@ def change_user_type_to_manager(project: Project) -> None:
 def change_user_type_to_employee(pk_set: Set) -> None:
     for user_id in pk_set:
         user = CustomUser.objects.get(pk=user_id)
-        if not user.manager_projects.exists():
+        if not user.manager_projects.exists() and user.user_type != CustomUser.UserType.ADMIN.name:
             user.user_type = CustomUser.UserType.EMPLOYEE.name
             user.full_clean()
             user.save()

--- a/managers/tests/test_unit_project_signals.py
+++ b/managers/tests/test_unit_project_signals.py
@@ -17,6 +17,11 @@ class TestProjectSignals(TestCase):
         )
         self.manager.full_clean()
         self.manager.save()
+        self.admin = CustomUser(
+            email="admin@codepoets.it", password="adminpasswd", user_type=CustomUser.UserType.ADMIN.name
+        )
+        self.admin.full_clean()
+        self.admin.save()
         self.project = Project(name="Test Project", start_date=timezone.now())
         self.project.full_clean()
         self.project.save()
@@ -33,3 +38,15 @@ class TestProjectSignals(TestCase):
         self.client.post(path=f"/admin/managers/project/{self.project.pk}/change/", args=self.project)
         self.manager.refresh_from_db()
         self.assertEqual(self.manager.user_type, CustomUser.UserType.EMPLOYEE.name)
+
+    def test_admin_should_not_be_updated_to_manager_when_he_is_assigne_as_a_project_manager(self):
+        self.project.managers.add(self.admin)
+        self.client.post(path="/admin/managers/project/add/", args=self.project)
+        self.admin.refresh_from_db()
+        self.assertEqual(self.admin.user_type, CustomUser.UserType.ADMIN.name)
+
+    def test_admin_should_not_be_updated_to_employee_when_he_is_no_longer_manager_of_any_project(self):
+        self.project.managers.remove(self.admin)
+        self.client.post(path=f"/admin/managers/project/{self.project.pk}/change/", args=self.project)
+        self.admin.refresh_from_db()
+        self.assertEqual(self.admin.user_type, CustomUser.UserType.ADMIN.name)


### PR DESCRIPTION
Resolves: https://github.com/Code-Poets/sheetstorm/issues/159

Admin user type shouldn't change to `Manager` after assignee him as a project manager.