### PR TITLE
Bugfix no project selected on join crash

### DIFF
--- a/employees/common/strings.py
+++ b/employees/common/strings.py
@@ -22,6 +22,7 @@ class ReportListStrings(NotCallableMixin, Enum):
     TASK_ACTIVITIES_COLUMN_HEADER = ugettext_lazy("Task Activity")
     DESCRIPTION_COLUMN_HEADER = ugettext_lazy("Description")
     EDIT_REPORT_BUTTON = ugettext_lazy("Edit")
+    NO_PROJECTS_TO_JOIN = ugettext_lazy("There are no other projects available.")
 
 
 class ReportDetailStrings(NotCallableMixin, Enum):

--- a/employees/templates/employees/report_list.html
+++ b/employees/templates/employees/report_list.html
@@ -24,11 +24,14 @@
 </div>
 
 <div id="dialog" style="display: none" title="{{ UI_text.JOIN_POPUP_HEADER.value }}" align="center">
-    <form action="{% url 'custom-report-list' %}" method="POST">
+    <form action="{% url 'custom-report-list' %}" id="join_form" method="POST">
         {% csrf_token %}
         {{ project_form }}
         <input type="submit" name="join" value="{{ UI_text.JOIN_POPUP_YES.value }}">
     </form>
+    {% if hide_join %}
+        {{ UI_text.NO_PROJECTS_TO_JOIN.value }}
+    {% endif %}
 </div>
 
 </br>
@@ -86,4 +89,9 @@
         var join_discard_text = "{{ UI_text.JOIN_POPUP_NO.value }}";
     </script>
     <script src="{% static 'employees/scripts/join_popup_window.js' %}"></script>
+    {% if hide_join %}
+        <script type="text/javascript">
+            document.getElementById("join_form").hidden = true;
+        </script>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
Resolves #141 

**Done:**

- If there are no projects available for joining, the form with project selection visible in popup is replaced with appropriate message, preventing user from submitting an empty form resulting in app crash