### PR TITLE
Bugfix add styles to admin report detail

### DIFF
--- a/employees/static/employees/style.css
+++ b/employees/static/employees/style.css
@@ -111,7 +111,7 @@
     text-align: right;
 }
 
-textarea.form-control {
-      height: 200px;
-      resize: vertical;
+textarea.form-control, #id_description {
+    height: 200px;
+    resize: none;
 }

--- a/employees/templates/employees/admin_report_detail.html
+++ b/employees/templates/employees/admin_report_detail.html
@@ -4,6 +4,10 @@
 {% load static %}
 {% load crispy_forms_tags %}
 
+{% block extra_head %}
+    <link rel="stylesheet" type="text/css" href="{% static 'employees/style.css' %}">
+{% endblock %}
+
 {% block content %}
 <h1>{{ UI_text.PAGE_TITLE.value }}{{ report.project }} ({{ report.date }})</h1>
 <div class="modal-dialog">


### PR DESCRIPTION
Resolves: https://github.com/Code-Poets/sheetstorm/issues/173
**Done**
 - description field is not resizable
 - added css to `admin_report_detail.html`

Size is smaller than you expected @maciejSamerdak I think it was looking different due to localization of description field in form.

