### PR TITLE
Bugfix add return button on user's report editting screen

### DIFF
--- a/employees/common/strings.py
+++ b/employees/common/strings.py
@@ -67,6 +67,7 @@ class AuthorReportListStrings(NotCallableMixin, Enum):
     EDITED_COLUMN_HEADER = ugettext_lazy("Edited")
     TASK_ACTIVITY_HEADER = ugettext_lazy("Task Activity")
     NO_REPORTS_MESSAGE = ugettext_lazy("This employee has no reports to display.")
+    RETURN_BUTTON_MESSAGE = ugettext_lazy("Back to employee list")
 
 
 class AdminReportDetailStrings(NotCallableMixin, Enum):

--- a/employees/templates/employees/author_report_list.html
+++ b/employees/templates/employees/author_report_list.html
@@ -10,6 +10,9 @@
 
 {% block content %}
 <h1>{{ object.email }}{{ UI_text.PAGE_TITLE.value }}</h1>
+<a href="{% url 'custom-users-list' %}" class="btn btn-primary">
+    {{ UI_text.RETURN_BUTTON_MESSAGE.value }}
+</a>
 <div class="container">
     <div class="table-responsive">
         <table class="table">


### PR DESCRIPTION
Resolves: https://github.com/Code-Poets/sheetstorm/issues/172

**Done**
 - Added return button to employee list in template

@Karrp @maciejSamerdak @kbeker @MartynaAnnaGottschling 
Where this button should located, because I am not sure. I have created it above report list but under the header.