### PR TITLE
Feature add export reports to xlsx

### DIFF
--- a/employees/common/constants.py
+++ b/employees/common/constants.py
@@ -10,3 +10,29 @@ class ReportModelConstants(Enum):
 
 class TaskActivityTypeConstans(Enum):
     TASK_ACTIVITIES_MAX_LENGTH = 30
+
+
+class ExcelGeneratorSettingsConstants(Enum):
+    TOTAL = "Total"
+    HEADERS_ROW = 1
+    FIRST_ROW_FOR_DATA = 2
+    HEADERS_FOR_SINGLE_USER = ["Date", "Project", "Task activity", "Hours", "Description"]
+    COLUMNS_WIDTH_FOR_SINGLE_USER = [12, 20, 30, 6, 100]
+    COLUMNS_WIDTH_FOR_PROJECT = [12, 30, 6, 100]
+    HEADERS_FOR_USER_IN_PROJECT = ["Date", "Task activity", "Hours", "Description"]
+    HOURS_COLUMN_FOR_REPORTS_IN_PROJECT = 3
+    TOTAL_COLUMN = 1
+    DESCRIPTION_COLUMN_FOR_SINGLE_USER = 5
+    DESCRIPTION_COLUMN_FOR_REPORTS_IN_PROJECT = 4
+    HOURS_COLUMN_FOR_SINGLE_USER = 4
+    VERCTICAL_TOP = "top"
+    CENTER_ALINGMENT = "center"
+    FONT = "Calibri"
+    HOURS_FORMAT = "h:mm"
+    TIMEVALUE_FORMULA = '=timevalue("{}")'
+    TOTAL_HOURS_FORMAT = "[h]:mm"
+    TOTAL_HOURS_FORMULA_FOR_SINGLE_USER = "=SUM(D1:D{})"
+    TOTAL_HOURS_FORMULA_REPORTS_IN_PROJECT = "=SUM(C1:C{})"
+    CONTENT_TYPE_FORMAT = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    EXPORTED_FILE_NAME = 'attachment; filename="{}_{}-reports.xlsx"'
+    BORDER = "double"

--- a/employees/common/exports.py
+++ b/employees/common/exports.py
@@ -1,0 +1,137 @@
+from openpyxl import Workbook
+from openpyxl.cell import Cell
+from openpyxl.styles import Alignment
+from openpyxl.styles import Font
+from openpyxl.utils import get_column_letter
+from openpyxl.worksheet.worksheet import Worksheet
+
+from employees.common.constants import ExcelGeneratorSettingsConstants
+from users.models import CustomUser
+
+
+def set_format_styles_for_main_cells(cell: Cell):
+    cell.font = Font(name=ExcelGeneratorSettingsConstants.FONT.value, bold=True)
+    cell.alignment = Alignment(horizontal=ExcelGeneratorSettingsConstants.CENTER_ALINGMENT.value)
+
+
+def set_columns_width(worksheet: Worksheet, col_num: int, width_settings: list):
+    column_letter = get_column_letter(col_num)
+    column_dimensions = worksheet.column_dimensions[column_letter]
+    column_dimensions.width = ExcelGeneratorSettingsConstants.COLUMNS_WIDTH_FOR_SINGLE_USER.value[col_num - 1]
+
+
+def fill_headers(worksheet: Worksheet, headers: list, width_settings: list):
+    for col_num, column_title in enumerate(headers, 1):
+        cell = worksheet.cell(row=ExcelGeneratorSettingsConstants.HEADERS_ROW.value, column=col_num)
+        cell.value = column_title
+        set_format_styles_for_main_cells(cell)
+        set_columns_width(worksheet, col_num, width_settings)
+
+
+def set_and_fill_description_cell(cell: Cell, cell_value: str):
+    wrapped_alignment = Alignment(vertical=ExcelGeneratorSettingsConstants.VERCTICAL_TOP.value, wrap_text=True)
+    cell.alignment = wrapped_alignment
+    cell.value = cell_value
+
+
+def set_and_fill_hours_cell(cell: Cell, cell_value: str):
+    cell.value = ExcelGeneratorSettingsConstants.TIMEVALUE_FORMULA.value.format(cell_value)
+    cell.number_format = ExcelGeneratorSettingsConstants.HOURS_FORMAT.value
+
+
+def fill_current_report_data(storage_data: dict):
+    for col_num, cell_value in enumerate(storage_data["data"], 1):
+        cell = storage_data["worksheet"].cell(row=storage_data["current_row"], column=col_num)
+        if col_num == storage_data["description_column"]:
+            set_and_fill_description_cell(cell, cell_value)
+        elif col_num == storage_data["hours_column"]:
+            set_and_fill_hours_cell(cell, cell_value)
+        else:
+            cell.value = cell_value
+
+
+def summarizing_reports(worksheet: Worksheet, last_row: int, hours_column: int, formula: str):
+    total_cell = worksheet.cell(row=last_row, column=ExcelGeneratorSettingsConstants.TOTAL_COLUMN.value)
+    total_cell.value = ExcelGeneratorSettingsConstants.TOTAL.value
+    set_format_styles_for_main_cells(total_cell)
+    total_hours_cell = worksheet.cell(row=last_row, column=hours_column)
+    total_hours_cell.value = formula.format(last_row - 1)
+    total_hours_cell.number_format = ExcelGeneratorSettingsConstants.TOTAL_HOURS_FORMAT.value
+    set_format_styles_for_main_cells(total_hours_cell)
+
+
+def set_active_worksheet_name(workbook: Workbook, author: CustomUser) -> Worksheet:
+    worksheet = workbook.active
+    worksheet.title = f"{author.first_name} {author.last_name[0]}"
+    return worksheet
+
+
+def generate_xlsx_for_single_user(author: CustomUser) -> Workbook:
+    reports = author.get_reports_created()
+    workbook = Workbook()
+    worksheet = set_active_worksheet_name(workbook, author)
+    fill_headers(
+        worksheet,
+        ExcelGeneratorSettingsConstants.HEADERS_FOR_SINGLE_USER.value,
+        ExcelGeneratorSettingsConstants.COLUMNS_WIDTH_FOR_SINGLE_USER.value,
+    )
+    current_row = ExcelGeneratorSettingsConstants.FIRST_ROW_FOR_DATA.value
+
+    for report in reports:
+        report_data = {
+            "data": [
+                report.date,
+                report.project.name,
+                report.task_activities.name,
+                report.work_hours_str,
+                report.description,
+            ],
+            "worksheet": worksheet,
+            "current_row": current_row,
+            "description_column": ExcelGeneratorSettingsConstants.DESCRIPTION_COLUMN_FOR_SINGLE_USER.value,
+            "hours_column": ExcelGeneratorSettingsConstants.HOURS_COLUMN_FOR_SINGLE_USER.value,
+        }
+        fill_current_report_data(report_data)
+        current_row += 1
+
+    summarizing_reports(
+        worksheet,
+        current_row,
+        ExcelGeneratorSettingsConstants.HOURS_COLUMN_FOR_SINGLE_USER.value,
+        ExcelGeneratorSettingsConstants.TOTAL_HOURS_FORMULA_FOR_SINGLE_USER.value,
+    )
+    return workbook
+
+
+def generate_xlsx_for_project(project: Project) -> Workbook:
+    authors = project.members.all()
+    workbook = Workbook()
+    for author in authors:
+        worksheet = set_active_worksheet_name(workbook, author)
+        reports = author.projects.get(pk=project.pk).report_set.filter(author_id=author.pk)
+        fill_headers(
+            worksheet,
+            ExcelGeneratorSettingsConstants.HEADERS_FOR_USER_IN_PROJECT.value,
+            ExcelGeneratorSettingsConstants.COLUMNS_WIDTH_FOR_PROJECT.value,
+        )
+
+        current_row = ExcelGeneratorSettingsConstants.FIRST_ROW_FOR_DATA.value
+        for report in reports:
+            storage_data = {
+                "data": [report.date, report.task_activities.name, report.work_hours_str, report.description],
+                "worksheet": worksheet,
+                "current_row": current_row,
+                "description_column": ExcelGeneratorSettingsConstants.DESCRIPTION_COLUMN_FOR_REPORTS_IN_PROJECT.value,
+                "hours_column": ExcelGeneratorSettingsConstants.HOURS_COLUMN_FOR_REPORTS_IN_PROJECT.value,
+            }
+            fill_current_report_data(storage_data)
+            current_row += 1
+        summarizing_reports(
+            worksheet,
+            current_row,
+            ExcelGeneratorSettingsConstants.HOURS_COLUMN_FOR_REPORTS_IN_PROJECT.value,
+            ExcelGeneratorSettingsConstants.TOTAL_HOURS_FORMULA_REPORTS_IN_PROJECT.value,
+        )
+        if author != authors.last():
+            workbook.create_sheet(index=0)
+    return workbook

--- a/employees/common/exports.py
+++ b/employees/common/exports.py
@@ -6,6 +6,7 @@ from openpyxl.utils import get_column_letter
 from openpyxl.worksheet.worksheet import Worksheet
 
 from employees.common.constants import ExcelGeneratorSettingsConstants
+from managers.models import Project
 from users.models import CustomUser
 
 
@@ -17,7 +18,7 @@ def set_format_styles_for_main_cells(cell: Cell):
 def set_columns_width(worksheet: Worksheet, col_num: int, width_settings: list):
     column_letter = get_column_letter(col_num)
     column_dimensions = worksheet.column_dimensions[column_letter]
-    column_dimensions.width = ExcelGeneratorSettingsConstants.COLUMNS_WIDTH_FOR_SINGLE_USER.value[col_num - 1]
+    column_dimensions.width = width_settings[col_num - 1]
 
 
 def fill_headers(worksheet: Worksheet, headers: list, width_settings: list):

--- a/employees/common/exports.py
+++ b/employees/common/exports.py
@@ -1,7 +1,9 @@
 from openpyxl import Workbook
 from openpyxl.cell import Cell
 from openpyxl.styles import Alignment
+from openpyxl.styles import Border
 from openpyxl.styles import Font
+from openpyxl.styles import Side
 from openpyxl.utils import get_column_letter
 from openpyxl.worksheet.worksheet import Worksheet
 
@@ -10,9 +12,14 @@ from managers.models import Project
 from users.models import CustomUser
 
 
-def set_format_styles_for_main_cells(cell: Cell):
+def set_format_styles_for_main_cells(cell: Cell, is_header: bool):
     cell.font = Font(name=ExcelGeneratorSettingsConstants.FONT.value, bold=True)
     cell.alignment = Alignment(horizontal=ExcelGeneratorSettingsConstants.CENTER_ALINGMENT.value)
+    cell.border = (
+        Border(bottom=Side(style=ExcelGeneratorSettingsConstants.BORDER.value))
+        if is_header
+        else Border(top=Side(style=ExcelGeneratorSettingsConstants.BORDER.value))
+    )
 
 
 def set_columns_width(worksheet: Worksheet, col_num: int, width_settings: list):
@@ -25,7 +32,7 @@ def fill_headers(worksheet: Worksheet, headers: list, width_settings: list):
     for col_num, column_title in enumerate(headers, 1):
         cell = worksheet.cell(row=ExcelGeneratorSettingsConstants.HEADERS_ROW.value, column=col_num)
         cell.value = column_title
-        set_format_styles_for_main_cells(cell)
+        set_format_styles_for_main_cells(cell, is_header=True)
         set_columns_width(worksheet, col_num, width_settings)
 
 
@@ -54,11 +61,11 @@ def fill_current_report_data(storage_data: dict):
 def summarizing_reports(worksheet: Worksheet, last_row: int, hours_column: int, formula: str):
     total_cell = worksheet.cell(row=last_row, column=ExcelGeneratorSettingsConstants.TOTAL_COLUMN.value)
     total_cell.value = ExcelGeneratorSettingsConstants.TOTAL.value
-    set_format_styles_for_main_cells(total_cell)
+    set_format_styles_for_main_cells(total_cell, is_header=False)
     total_hours_cell = worksheet.cell(row=last_row, column=hours_column)
     total_hours_cell.value = formula.format(last_row - 1)
     total_hours_cell.number_format = ExcelGeneratorSettingsConstants.TOTAL_HOURS_FORMAT.value
-    set_format_styles_for_main_cells(total_hours_cell)
+    set_format_styles_for_main_cells(total_hours_cell, is_header=False)
 
 
 def set_active_worksheet_name(workbook: Workbook, author: CustomUser) -> Worksheet:

--- a/employees/templates/employees/author_report_list.html
+++ b/employees/templates/employees/author_report_list.html
@@ -15,6 +15,9 @@
 <h1>{{ object.email }}{{ UI_text.PAGE_TITLE.value }}</h1>
 <a href="{% url 'custom-users-list' %}" class="btn btn-primary hidden-print">
     {{ UI_text.RETURN_BUTTON_MESSAGE.value }}
+    <a href="{% url 'export-data-xlsx' pk=object.id %}" class="btn btn-info">
+        Export Reports
+    </a>
 </a>
 <div class="container">
     <div class="table-responsive">

--- a/employees/templates/employees/project_report_list.html
+++ b/employees/templates/employees/project_report_list.html
@@ -13,6 +13,9 @@
 
 {% block content %}
 <h1>{{ object.name }}{{ UI_text.PAGE_TITLE.value }}</h1>
+<a href="{% url 'export-project-data-xlsx' pk=object.pk %}" class="btn btn-info">
+        Export Reports
+</a>
 <div class="container">
     <div class="table-responsive">
         {% regroup object.get_report_ordered by author as reports_by_author %}

--- a/employees/tests/test_unit_export_data.py
+++ b/employees/tests/test_unit_export_data.py
@@ -1,0 +1,102 @@
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from employees.common.constants import ExcelGeneratorSettingsConstants
+from employees.common.exports import generate_xlsx_for_project
+from employees.common.exports import generate_xlsx_for_single_user
+from employees.common.strings import TaskActivitiesStrings
+from employees.factories import ReportFactory
+from managers.factories import ProjectFactory
+from users.factories import UserFactory
+
+
+class DataSetUpToTests(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+        self.project = ProjectFactory(
+            name="aaa",
+            start_date=timezone.now() + timezone.timedelta(days=1),
+            stop_date=timezone.now() + timezone.timedelta(days=6),
+        )
+        self.report = ReportFactory(author=self.user, project=self.project)
+        self.project.members.add(self.user)
+        self.data = {"project": self.project.pk, "author": self.user.pk}
+        self.url_single_user = reverse("export-data-xlsx", kwargs={"pk": self.user.pk})
+        self.url_project = reverse("export-project-data-xlsx", kwargs={"pk": self.data["project"]})
+        self.workbook_for_project = generate_xlsx_for_project(self.project)
+        self.workbook_for_user = generate_xlsx_for_single_user(self.user)
+
+
+class ExportViewTest(DataSetUpToTests):
+    def test_export_reports_should_download_for_single_user_if_he_is_logged(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url_single_user)
+        self.assertEqual(response.status_code, 200)
+
+    def test_export_reports_should_not_download_data_if_he_is_not_logged(self):
+        response = self.client.get(self.url_single_user)
+        self.assertEqual(response.status_code, 302)
+
+    def test_export_reports_for_project_should_download_if_user_is_logged(self):
+        self.client.force_login(self.user)
+        response = self.client.get(self.url_project)
+        self.assertEqual(response.status_code, 200)
+
+    def test_export_reports_for_project_should_not_download_if_user_is_not_logged(self):
+        response = self.client.get(self.url_project)
+        self.assertEqual(response.status_code, 302)
+
+
+class ExportMethodTestForProject(DataSetUpToTests):
+    def test_sheetnames_should_have_name_and_first_letter_of_surname_and_one_sheet(self):
+        authors = self.workbook_for_project.get_sheet_names()
+        for author in authors:
+            self.assertEqual(author, f"{self.user.first_name} {self.user.last_name[0]}")
+        self.assertEqual(len(authors), 1)
+
+    def test_date_should_be_the_same_in_excel(self):
+        self.assertEqual(self.report.date, str(self.workbook_for_project.active.cell(row=2, column=1).value))
+
+    def test_task_activity_should_be_the_same_in_excel(self):
+        self.assertEqual(
+            TaskActivitiesStrings.OTHER.value, self.workbook_for_project.active.cell(row=2, column=2).value
+        )
+
+    def test_hours_should_be_the_same_in_excel(self):
+        work_hours = f"{self.report.work_hours_str}"
+        self.assertEqual(
+            ExcelGeneratorSettingsConstants.TIMEVALUE_FORMULA.value.format(work_hours),
+            self.workbook_for_project.active.cell(row=2, column=3).value,
+        )
+
+    def test_description_should_be_the_same_in_excel(self):
+        self.assertEqual(self.report.description, self.workbook_for_project.active.cell(row=2, column=4).value)
+
+
+class ExportMethodTestForSingleUser(DataSetUpToTests):
+    def test_sheetnames_should_have_name_and_first_letter_of_surname_and_one_sheet(self):
+        sheet_names = self.workbook_for_user.get_sheet_names()
+        for author in sheet_names:
+            self.assertEqual(author, f"{self.user.first_name} {self.user.last_name[0]}")
+        self.assertEqual(len(sheet_names), 1)
+
+    def test_date_should_be_the_same_in_excel(self):
+        self.assertEqual(self.report.date, str(self.workbook_for_user.active.cell(row=2, column=1).value))
+
+    def test_project_name_should_be_the_same_in_excel(self):
+        self.assertEqual(self.report.project.name, str(self.workbook_for_user.active.cell(row=2, column=2).value))
+
+    def test_task_activity_should_be_the_same_in_excel(self):
+        self.assertEqual(TaskActivitiesStrings.OTHER.value, self.workbook_for_user.active.cell(row=2, column=3).value)
+
+    def test_hours_should_be_the_same_in_excel(self):
+        work_hours = f"{self.report.work_hours_str}"
+        self.assertEqual(
+            ExcelGeneratorSettingsConstants.TIMEVALUE_FORMULA.value.format(work_hours),
+            self.workbook_for_user.active.cell(row=2, column=4).value,
+        )
+
+    def test_description_should_be_the_same_in_excel(self):
+        self.assertEqual(self.report.description, self.workbook_for_user.active.cell(row=2, column=5).value)

--- a/employees/urls.py
+++ b/employees/urls.py
@@ -18,5 +18,10 @@ urlpatterns = [
     url(r"^reports/management/(?P<pk>[0-9]+)/$", views.AdminReportView.as_view(), name="admin-report-detail"),
     url(r"^reports/project/(?P<pk>[0-9]+)/$", views.ProjectReportList.as_view(), name="project-report-list"),
     url(r"^reports/project/report/(?P<pk>[0-9]+)/$", views.ProjectReportDetail.as_view(), name="project-report-detail"),
-    url("^export/user-reports/(?P<pk>[0-9]+)/$", views.ExportUserReportView.as_view(), name="export-data-xlsx"),
+    url(r"^export/user-reports/(?P<pk>[0-9]+)/$", views.ExportUserReportView.as_view(), name="export-data-xlsx"),
+    url(
+        r"^export/project-reports/(?P<pk>[0-9]+)/$",
+        views.ExportReportsInProjectView.as_view(),
+        name="export-project-data-xlsx",
+    ),
 ]

--- a/employees/urls.py
+++ b/employees/urls.py
@@ -18,4 +18,5 @@ urlpatterns = [
     url(r"^reports/management/(?P<pk>[0-9]+)/$", views.AdminReportView.as_view(), name="admin-report-detail"),
     url(r"^reports/project/(?P<pk>[0-9]+)/$", views.ProjectReportList.as_view(), name="project-report-list"),
     url(r"^reports/project/report/(?P<pk>[0-9]+)/$", views.ProjectReportDetail.as_view(), name="project-report-detail"),
+    url("^export/user-reports/(?P<pk>[0-9]+)/$", views.ExportUserReportView.as_view(), name="export-data-xlsx"),
 ]

--- a/employees/views.py
+++ b/employees/views.py
@@ -22,6 +22,8 @@ from rest_framework import viewsets
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from employees.common.constants import ExcelGeneratorSettingsConstants
+from employees.common.exports import generate_xlsx_for_project
 from employees.common.exports import generate_xlsx_for_single_user
 from employees.common.strings import AdminReportDetailStrings
 from employees.common.strings import AuthorReportListStrings
@@ -291,5 +293,20 @@ class ExportUserReportView(LoginRequiredMixin, DetailView):
             author.email, datetime.date.today()
         )
         work_book = generate_xlsx_for_single_user(author)
+        work_book.save(response)
+        return response
+
+
+@method_decorator(login_required, name="dispatch")
+class ExportReportsInProjectView(LoginRequiredMixin, DetailView):
+    model = Project
+
+    def render_to_response(self, context: dict, **response_kwargs: Any) -> HttpResponse:
+        project = super().get_object()
+        response = HttpResponse(content_type=ExcelGeneratorSettingsConstants.CONTENT_TYPE_FORMAT.value)
+        response["Content-Disposition"] = ExcelGeneratorSettingsConstants.EXPORTED_FILE_NAME.value.format(
+            project.name, datetime.date.today()
+        )
+        work_book = generate_xlsx_for_project(project)
         work_book.save(response)
         return response

--- a/requirements.lock
+++ b/requirements.lock
@@ -33,6 +33,7 @@ more-itertools==7.0.0
 mypy==0.701
 mypy-extensions==0.4.1
 oauthlib==3.0.1
+openpyxl==2.6.0
 parameterized==0.7.0
 pluggy==0.11.0
 psycopg2==2.7.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ mypy
 Markdown
 markdown-checklists
 oauthlib
+openpyxl
 psycopg2
 pylint
 parameterized


### PR DESCRIPTION
Resolves: https://github.com/Code-Poets/sheetstorm/issues/161

This feature should give us possibility to export reports to excel compatible format. In this case it should be `xlsx` format.

**Done**
 - Reports are covnerted to `xlsx` format
 - Reports for single user should have `Date , Projects, Task activities, hours, description` columns
 - Last row should have functional total hours counter.
 - Reports for project should have `Date, Task activities, Hours, Description' columns and sheet per employee

**Unresolved yet**
 - Tests for this feature
 - [x] I have a problem with markdown, if someone has description with markdowns symbols then we could see it in excel like: `** Important message **, #Header, - something` *
 - View returned all reports without date filtered. I think that it would be better to implement it when those features will be merged : 
https://github.com/Code-Poets/sheetstorm/pull/138
https://github.com/Code-Poets/sheetstorm/pull/139
But I am not sure.

***We have to delete markdown from description**