### PR TITLE
Bugfix 24 hours validation does not work on report creation

### DIFF
--- a/employees/serializers.py
+++ b/employees/serializers.py
@@ -50,7 +50,7 @@ class ReportSerializer(serializers.HyperlinkedModelSerializer):
         model = Report
         fields = ("url", "date", "project", "author", "task_activities", "description", "work_hours")
 
-    def to_representation(self, instance: Report) -> Report:
+    def to_representation(self, instance: Report) -> OrderedDict:
         data = super().to_representation(instance)
         if isinstance(self.instance, Report):
             data["work_hours"] = self.instance.work_hours_str

--- a/employees/serializers.py
+++ b/employees/serializers.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from decimal import Decimal
 from typing import Any
 
@@ -6,6 +7,7 @@ from rest_framework import serializers
 from employees.common.constants import ReportModelConstants
 from employees.common.strings import MAX_HOURS_VALUE_VALIDATOR_MESSAGE
 from employees.common.strings import MIN_HOURS_VALUE_VALIDATOR_MESSAGE
+from employees.common.strings import ReportValidationStrings
 from employees.common.validators import MaxDecimalValueValidator
 from employees.models import Report
 from employees.models import TaskActivityType
@@ -52,4 +54,25 @@ class ReportSerializer(serializers.HyperlinkedModelSerializer):
         data = super().to_representation(instance)
         if isinstance(self.instance, Report):
             data["work_hours"] = self.instance.work_hours_str
+        return data
+
+    def validate(self, data: OrderedDict) -> OrderedDict:
+        data = super().validate(data)
+        if "date" in data:
+            author = None
+            pk = None
+            if self.instance is not None:
+                author = self.instance.author
+                pk = self.instance.pk
+            elif "request" in self.context:
+                author = self.context["request"].user
+            if (
+                author is not None
+                and author.report_set.get_report_work_hours_sum_for_date(for_date=data["date"], excluded_id=pk)
+                + data.get("work_hours", 0)
+                > 24
+            ):
+                raise serializers.ValidationError(
+                    detail=ReportValidationStrings.WORK_HOURS_SUM_FOR_GIVEN_DATE_FOR_SINGLE_AUTHOR_EXCEEDED.value
+                )
         return data

--- a/employees/templates/employees/report_detail.html
+++ b/employees/templates/employees/report_detail.html
@@ -13,6 +13,9 @@
 <h1>{{ UI_text.PAGE_TITLE.value }}{{ report.project }} ({{ report.date }})</h1>
 </br>
 <div class="modal-dialog">
+    {% for error in errors.non_field_errors %}
+    <h4><font color="red">{{ error }}</font></h4>
+    {% endfor %}
     <form action="{% url 'custom-report-detail' pk=report.pk %}" method="POST">
         {% csrf_token %}
         {% render_form serializer template_pack='rest_framework/vertical' %}

--- a/employees/templates/employees/report_list.html
+++ b/employees/templates/employees/report_list.html
@@ -18,6 +18,9 @@
 <input class="hidden-print" type="button" id="opener" value="{{ UI_text.JOIN_PROJECT_BUTTON.value }}"/>
 
 <div class="modal-dialog hidden-print">
+    {% for error in errors.non_field_errors %}
+    <h4><font color="red">{{ error }}</font></h4>
+    {% endfor %}
     <form action="{% url 'custom-report-list' %}" method="POST">
         {% csrf_token %}
         {% render_form serializer template_pack='rest_framework/vertical' %}

--- a/employees/tests/test_unit_report_serializer.py
+++ b/employees/tests/test_unit_report_serializer.py
@@ -58,6 +58,98 @@ class ReportSerializerTests(DataSetUpToTests):
     def test_report_serializer_work_hours_field_should_accept_correct_value(self):
         self.field_should_accept_input(field="work_hours", value=Decimal("8.00"))
 
+    def test_report_serializer_should_be_valid_total_sum_of_hours_from_single_day_for_single_author_is_24(self):
+        report = Report(
+            date=datetime.datetime.now().date(),
+            description=self.required_input["description"],
+            author=self.required_input["author"],
+            project=self.required_input["project"],
+            work_hours=Decimal("12.00"),
+        )
+        report.full_clean()
+        report.save()
+        request = APIRequestFactory().get(path=reverse("custom-report-list"))
+        data = self.required_input.copy()
+        data["work_hours"] = Decimal("12.00")
+        request.user = data["author"]
+        serializer = ReportSerializer(data=data, context={"request": request})
+        self.assertTrue(serializer.is_valid())
+
+    def test_report_serializer_should_raise_error_if_total_sum_of_hours_from_single_day_for_single_author_exceeds_24(
+        self
+    ):
+        report = Report(
+            date=datetime.datetime.now().date(),
+            description=self.required_input["description"],
+            author=self.required_input["author"],
+            project=self.required_input["project"],
+            work_hours=Decimal("12.00"),
+        )
+        report.full_clean()
+        report.save()
+        request = APIRequestFactory().get(path=reverse("custom-report-list"))
+        data = self.required_input.copy()
+        data["work_hours"] = Decimal("12.01")
+        request.user = data["author"]
+        serializer = ReportSerializer(data=data, context={"request": request})
+        self.assertFalse(serializer.is_valid())
+
+    def test_report_serializer_based_on_instance_should_be_valid_total_sum_of_hours_from_single_day_for_single_author_is_24(
+        self
+    ):
+        report = Report(
+            date=datetime.datetime.now().date(),
+            description=self.required_input["description"],
+            author=self.required_input["author"],
+            project=self.required_input["project"],
+            work_hours=Decimal("10.00"),
+        )
+        report.full_clean()
+        report.save()
+        other_report = Report(
+            date=datetime.datetime.now().date(),
+            description=self.required_input["description"],
+            author=self.required_input["author"],
+            project=self.required_input["project"],
+            work_hours=Decimal("12.00"),
+        )
+        other_report.full_clean()
+        other_report.save()
+        request = APIRequestFactory().get(path=reverse("custom-report-detail", args=(report.pk,)))
+        data = self.required_input.copy()
+        data["work_hours"] = Decimal("12.00")
+        request.user = data["author"]
+        serializer = ReportSerializer(instance=report, data=data, context={"request": request})
+        self.assertTrue(serializer.is_valid())
+
+    def test_report_serializer_based_on_instance_should_raise_error_if_total_sum_of_hours_from_single_day_for_single_author_exceeds_24(
+        self
+    ):
+        report = Report(
+            date=datetime.datetime.now().date(),
+            description=self.required_input["description"],
+            author=self.required_input["author"],
+            project=self.required_input["project"],
+            work_hours=Decimal("10.00"),
+        )
+        report.full_clean()
+        report.save()
+        other_report = Report(
+            date=datetime.datetime.now().date(),
+            description=self.required_input["description"],
+            author=self.required_input["author"],
+            project=self.required_input["project"],
+            work_hours=Decimal("12.00"),
+        )
+        other_report.full_clean()
+        other_report.save()
+        request = APIRequestFactory().get(path=reverse("custom-report-detail", args=(report.pk,)))
+        data = self.required_input.copy()
+        data["work_hours"] = Decimal("12.01")
+        request.user = data["author"]
+        serializer = ReportSerializer(instance=report, data=data, context={"request": request})
+        self.assertFalse(serializer.is_valid())
+
 
 class ReportSerializerDateFailTests(DataSetUpToTests):
     def test_report_serializer_date_field_should_not_be_empty(self):


### PR DESCRIPTION
Resolves #221 
Related #229 

Done:
- Custom `validate` method with 24 hours per day verification has been implemented for ReportSerializer
- Templates for report creation and update have been updated to display non-field errors
- Bug related unit tests have been introduced in serializer unit tests