### PR TITLE
Bugfix-isort-fixing-info

### DIFF
--- a/style.sh
+++ b/style.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 printf "[ISORT: sheetstorm]\n"
-./find-files-to-refactor.sh | xargs isort -sl
+./find-files-to-refactor.sh | xargs isort -sl -l 120
 printf "\n"
 
 printf "[BLACK: sheetstorm]\n"


### PR DESCRIPTION
Resolves: https://github.com/Code-Poets/sheetstorm/issues/227
I have changed line length settings in isort because default it was 79, and change our import 
`from employees.templatetags.data_structure_element_selectors import get_key_value`
to
`from employees.templatetags.data_structure_element_selectors import /
get_key_value` - `get_key_value` was in new line