### PR TITLE
Add restriction for non numeric strings to ReportSerializer

### DIFF
--- a/employees/common/strings.py
+++ b/employees/common/strings.py
@@ -105,3 +105,4 @@ class ReportValidationStrings(NotCallableMixin, Enum):
         "Minimum value for work hours for single report must not be less than 1 minute"
     )
     WORK_HOURS_FIELD_NOT_TIMEDELTA_INSTANCE = _("Work hours field must be instance of timedelta")
+    WORK_HOURS_WRONG_FORMAT = _("Correct format of work hours field is: HH:MM")

--- a/employees/serializers.py
+++ b/employees/serializers.py
@@ -22,8 +22,10 @@ class HoursField(serializers.DurationField):
 
     def to_internal_value(self, data: str) -> timedelta:
         if str(data).count(":") != 1:
-            raise ValidationError()
+            raise ValidationError(detail=ReportValidationStrings.WORK_HOURS_WRONG_FORMAT.value)
         hours, minutes = str(data).split(":")
+        if not hours.isdigit() or not minutes.isdigit():
+            raise ValidationError(detail=ReportValidationStrings.WORK_HOURS_WRONG_FORMAT.value)
         return timedelta(hours=int(hours), minutes=int(minutes))
 
 

--- a/employees/tests/test_unit_report_serializer.py
+++ b/employees/tests/test_unit_report_serializer.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.test import TestCase
+from parameterized import parameterized
 from rest_framework.reverse import reverse
 from rest_framework.test import APIRequestFactory
 
@@ -165,11 +166,12 @@ class ReportSerializerWorkHoursFailTests(DataSetUpToTests):
     def test_report_serializer_work_hours_should_not_accept_non_numeric_value(self):
         self.field_should_not_accept_input(field="work_hours", value=self.sample_string_for_type_validation_tests)
 
+    @parameterized.expand(["08.00", ":", ".", "08:", ":60"])
+    def test_report_serializer_work_hours_field_should_not_accept_invalid_value(self, value):
+        self.field_should_not_accept_input(field="work_hours", value=value)
+
     def test_report_serializer_work_hours_field_should_not_be_empty(self):
         self.field_should_not_accept_null(field="work_hours")
-
-    def test_report_serializer_work_hours_field_should_not_accept_work_hours_value_with_dot(self):
-        self.field_should_not_accept_input(field="work_hours", value="08.00")
 
 
 class HoursFieldTests(TestCase):


### PR DESCRIPTION
No issue on that bug. This is bug appeared because of oversight