### PR TITLE
Feature month segregation for author report list

### DIFF
--- a/employees/templates/employees/author_report_list.html
+++ b/employees/templates/employees/author_report_list.html
@@ -8,11 +8,13 @@
 {% load data_structure_element_selectors %}
 
 {% block extra_head %}
+<link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/smoothness/jquery-ui.css">
 <link rel="stylesheet" type="text/css" href="{% static 'employees/style.css' %}">
 {% endblock %}
 
 {% block content %}
-<h1>{{ object.email }}{{ UI_text.PAGE_TITLE.value }}</h1>
+{% include "employees/month_navigation_bar.html" %}
+<h1>{{ object.email }} {{ title_date }}{{ UI_text.PAGE_TITLE.value }}</h1>
 <a href="{% url 'custom-users-list' %}" class="btn btn-primary hidden-print">
     {{ UI_text.RETURN_BUTTON_MESSAGE.value }}
     <a href="{% url 'export-data-xlsx' pk=object.id %}" class="btn btn-info">
@@ -80,4 +82,10 @@
         {% endif %}
     </div>
 </div>
+{% endblock %}
+
+{% block extra_script %}
+{{ month_form.media }}
+<script src="//code.jquery.com/jquery-1.12.4.js"></script>
+<script src="//code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
 {% endblock %}

--- a/employees/urls.py
+++ b/employees/urls.py
@@ -14,7 +14,11 @@ urlpatterns = [
     url(r"^reports/(?P<year>[0-9]{4})/(?P<month>[0-9]{1,2})/$", views.ReportList.as_view(), name="custom-report-list"),
     url(r"^reports/(?P<pk>[0-9]+)/$", views.ReportDetailView.as_view(), name="custom-report-detail"),
     url(r"^reports/(?P<pk>[0-9]+)/delete/$", views.ReportDeleteView.as_view(), name="custom-report-delete"),
-    url(r"^reports/author/(?P<pk>[0-9]+)/$", views.AuthorReportView.as_view(), name="author-report-list"),
+    url(
+        r"^reports/author/(?P<pk>[0-9]+)/(?P<year>[0-9]{4})/(?P<month>[0-9]{1,2})/$",
+        views.AuthorReportView.as_view(),
+        name="author-report-list",
+    ),
     url(r"^reports/management/(?P<pk>[0-9]+)/$", views.AdminReportView.as_view(), name="admin-report-detail"),
     url(
         r"^reports/project/(?P<pk>[0-9]+)/(?P<year>[0-9]{4})/(?P<month>[0-9]{1,2})/$",

--- a/users/templates/users_list.html
+++ b/users/templates/users_list.html
@@ -48,7 +48,7 @@
                         </a>
                     </td>
                     <td class=Invisible align="center">
-                        <a href="{% url 'author-report-list' pk=user.id %}" class="btn btn-warning">
+                        <a href="{% url 'author-report-list' pk=user.id year=year month=month %}" class="btn btn-warning">
                             <span class="glyphicon glyphicon-list-alt"></span>
                         </a>
                     </td>

--- a/users/views.py
+++ b/users/views.py
@@ -1,4 +1,6 @@
+import datetime
 import logging
+from typing import Any
 from typing import Optional
 from typing import Type
 from typing import Union
@@ -180,6 +182,12 @@ class UserList(ListView):
     template_name = "users_list.html"
     model = CustomUser
     queryset = CustomUser.objects.prefetch_related("projects")
+
+    def get_context_data(self, *, _object_list: Any = None, **kwargs: Any) -> dict:
+        context_data = super().get_context_data(**kwargs)
+        context_data["year"] = datetime.datetime.now().year
+        context_data["month"] = datetime.datetime.now().month
+        return context_data
 
 
 class CustomPasswordChangeView(PasswordChangeView):

--- a/utils/tests/test_access_permissions.py
+++ b/utils/tests/test_access_permissions.py
@@ -30,7 +30,9 @@ class AccessPermissionsTestCase(TestCase):
                 CustomUser.UserType.MANAGER.name,
                 CustomUser.UserType.ADMIN.name,
             ],
-            reverse("author-report-list", kwargs={"pk": self.user.pk}): [CustomUser.UserType.ADMIN.name],
+            reverse("author-report-list", kwargs={"pk": self.user.pk, "year": 2019, "month": 5}): [
+                CustomUser.UserType.ADMIN.name
+            ],
             reverse("admin-report-detail", kwargs={"pk": self.report.pk}): [CustomUser.UserType.ADMIN.name],
             reverse("project-report-list", kwargs={"pk": self.report.project.pk, "year": 2019, "month": 5}): [
                 CustomUser.UserType.MANAGER.name,


### PR DESCRIPTION
Resolves #25

Related #138

Done:
- Author's reports list view now displays reports from single month
- Month navigation bar was introduced to author report list
- User's list view has been updated to properly redirect to author's reports list