### PR TITLE
Disable code inspection on `sheetstorm-deployment` directory

### DIFF
--- a/find-files-to-refactor.sh
+++ b/find-files-to-refactor.sh
@@ -3,4 +3,5 @@
 find . -type f                              \
     -not -path "./sheetstorm/settings/*"    \
     -not -path "*/migrations/*"             \
-    -name "*.py"                     \
+    -not -path "*/sheetstorm-deployment/*"  \
+    -name "*.py"                            \

--- a/lint.sh
+++ b/lint.sh
@@ -2,7 +2,7 @@
 
 printf "[FLAKE8: sheetstorm]\n"
 flake8                                                                                                      \
-    --exclude=sheetstorm/settings/,manage.py,employees/migrations,users/migrations,managers/migrations,     \
+    --exclude=sheetstorm-deployment/,sheetstorm/settings/,manage.py,employees/migrations,users/migrations,managers/migrations,     \
     --jobs=4                                                                                                \
     --max-line-length=120                                                                                   \
     --ignore=E124,E126,E128,E131,E156,E201,E221,E222,E241,E265,E271,E272,E701,F405,E501,W503                \
@@ -12,5 +12,5 @@ printf "\n"
 printf "[PYLINT: sheetstorm]\n"
 # Find all subdirectories of our python apps and use xargs to pass them as arguments to pylint
 
-find . -type d | xargs pylint --rcfile=pylintrc
+./find-files-to-refactor.sh | xargs pylint --rcfile=pylintrc
 printf "\n"

--- a/manage.py
+++ b/manage.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
         from django.core.management import execute_from_command_line
     except ImportError:
         try:
-            import django
+            import django  # pylint: disable=unused-import
         except ImportError:
             raise ImportError(
                 "Couldn't import Django. Are you sure it's installed and "


### PR DESCRIPTION
No issue for that. After @bartoszbetka added deployment to sheetstorm repo `pylint` started to complain about some code and because of bug in `pylint` which does not allow to add ignoring path this had to be done this way how I changed in this PR.