### PR TITLE
Chore delete the django middleware that is responsible for sending 404 http error to the sentry environment

### DIFF
--- a/sheetstorm/settings/base.py
+++ b/sheetstorm/settings/base.py
@@ -63,7 +63,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'raven.contrib.django.raven_compat.middleware.Sentry404CatchMiddleware',
 ]
 
 ROOT_URLCONF = 'sheetstorm.urls'


### PR DESCRIPTION
A configuration that sends 404 http error causes a lot of spam traffic
which is not usually needed.