### PR TITLE
Feature default project for new report

### DIFF
--- a/employees/forms.py
+++ b/employees/forms.py
@@ -57,7 +57,9 @@ class ReportForm(forms.ModelForm):
 
     def __init__(self, *args: Any, **kwargs: Any):
         super(ReportForm, self).__init__(*args, **kwargs)
-        self.fields["project"].queryset = kwargs["initial"]["author"].projects.all()
+        self.fields["project"].queryset = kwargs["initial"]["author"].get_project_ordered_by_last_report_creation_date()
+        if self.fields["project"].queryset.exists():
+            self.initial["project"] = self.fields["project"].queryset.first()
 
 
 class MonthSwitchForm(forms.Form):


### PR DESCRIPTION
Resolves https://github.com/Code-Poets/sheetstorm/issues/29

TODO: Add test that ReportForm.projects field sets initial to project in which last report was created after https://github.com/Code-Poets/sheetstorm/pull/296 is merged.