### PR TITLE
Unify test naming by removing "that" from tests name schema

### DIFF
--- a/employees/tests/test_unit_custom_forms.py
+++ b/employees/tests/test_unit_custom_forms.py
@@ -39,14 +39,14 @@ class TestDurationFieldForm:
     @pytest.mark.parametrize(
         ("initial_value", "input_value", "expected_value"), [("08:00", "8:00", "8:00:00"), ("08:00", "8:0", "8:0:00")]
     )
-    def test_that_correct_work_hours_is_same_as_assumpted(self, initial_value, input_value, expected_value):
+    def test_correct_work_hours_is_same_as_assumpted(self, initial_value, input_value, expected_value):
         assertpy.assert_that(self._test_duration_field_form(initial_value, input_value)).is_equal_to(expected_value)
 
     @pytest.mark.parametrize(
         ("initial_value", "input_value"),
         [("08:00", ":00"), ("08:00", "8:"), ("08:00", ":"), ("08:00", ""), ("08:00", "four:zero"), ("08:00", "8:zero")],
     )
-    def test_that_incorrect_work_hours_will_raise_exception(self, initial_value, input_value):
+    def test_incorrect_work_hours_will_raise_exception(self, initial_value, input_value):
         with pytest.raises(ValidationError) as exception:
             self._test_duration_field_form(initial_value, input_value)
         assertpy.assert_that(exception.value.message).is_equal_to(ReportValidationStrings.WORK_HOURS_WRONG_FORMAT.value)

--- a/employees/tests/test_unit_export_data.py
+++ b/employees/tests/test_unit_export_data.py
@@ -175,7 +175,7 @@ class TestExportingFunctions(TestCase):
                 ReportFactory(author=self.employee, project=self.project, date=f"2019-06-{i}")
         self.report_asc = Report.objects.filter(author__id=self.employee.pk).order_by("-date")
 
-    def test_that_unsorted_reported_will_be_sorted_asc_in_project_export(self):
+    def test_unsorted_reported_will_be_sorted_asc_in_project_export(self):
         project_workbook = generate_xlsx_for_project(self.project)
         for i, element in enumerate(self.report_asc):
             if i % 2 == 0:
@@ -193,7 +193,7 @@ class TestExportingFunctions(TestCase):
                     None,
                 )
 
-    def test_that_unsorted_reported_will_be_sorted_asc_in_user_export(self):
+    def test_unsorted_reported_will_be_sorted_asc_in_user_export(self):
         project_workbook = generate_xlsx_for_single_user(self.employee)
         for i, element in enumerate(self.report_asc):
             if i % 2 == 0:

--- a/employees/tests/test_unit_report_model.py
+++ b/employees/tests/test_unit_report_model.py
@@ -162,7 +162,7 @@ class TestReportQuerySetWorkHoursSumForAllDates(InitTaskTypeTestCase):
 
 
 class TestReportWorkHoursSumForGivenDayForSingleUser(InitTaskTypeTestCase):
-    def test_that_work_hours_sum_for_given_day_for_single_user_can_be_24(self):
+    def test_work_hours_sum_for_given_day_for_single_user_can_be_24(self):
         user = UserFactory()
         today = timezone.now().date()
         report = ReportFactory(work_hours=datetime.timedelta(hours=23), date=today, author=user)
@@ -175,7 +175,7 @@ class TestReportWorkHoursSumForGivenDayForSingleUser(InitTaskTypeTestCase):
 
         self.assertEqual(user.report_set.get_report_work_hours_sum_for_date(today), datetime.timedelta(hours=24))
 
-    def test_that_work_hours_sum_for_given_day_for_single_user_should_not_exceed_24(self):
+    def test_work_hours_sum_for_given_day_for_single_user_should_not_exceed_24(self):
         user = UserFactory()
         today = timezone.now().date()
         report = ReportFactory(work_hours=datetime.timedelta(hours=23), date=today, author=user)
@@ -195,7 +195,7 @@ class TestReportWorkHoursSumForGivenDayForSingleUser(InitTaskTypeTestCase):
             ReportValidationStrings.WORK_HOURS_SUM_FOR_GIVEN_DATE_FOR_SINGLE_AUTHOR_EXCEEDED.value,
         )
 
-    def test_that_editing_report_work_hours_sum_for_given_day_for_single_user_should_not_exceed_24(self):
+    def test_editing_report_work_hours_sum_for_given_day_for_single_user_should_not_exceed_24(self):
         user = UserFactory()
         today = timezone.now().date()
         ReportFactory(work_hours=datetime.timedelta(hours=23), date=today, author=user)
@@ -210,7 +210,7 @@ class TestReportWorkHoursSumForGivenDayForSingleUser(InitTaskTypeTestCase):
             ReportValidationStrings.WORK_HOURS_SUM_FOR_GIVEN_DATE_FOR_SINGLE_AUTHOR_EXCEEDED.value,
         )
 
-    def test_that_edited_report_would_not_be_summed_twice_for_work_hours_sum(self):
+    def test_edited_report_would_not_be_summed_twice_for_work_hours_sum(self):
         user = UserFactory()
         today = timezone.now().date()
         work_hours = datetime.timedelta(hours=20)
@@ -250,7 +250,7 @@ class TestReportTaskActivitiesParameter(DataSetUpToTests):
         report = Report()
         self.assertEqual(TaskActivityType.objects.get(name="Other").name, report.task_activities.name)
 
-    def test_that_added_task_activity_must_be_accepted_as_correct_input(self):
+    def test_added_task_activity_must_be_accepted_as_correct_input(self):
         test_activity_type = TaskActivityType(pk=2, name="test")
         test_activity_type.full_clean()
         test_activity_type.save()

--- a/employees/tests/test_unit_templatetags.py
+++ b/employees/tests/test_unit_templatetags.py
@@ -24,7 +24,7 @@ class GetKeyValueTests(TestCase):
 
 
 class DurationHoursTests(TestCase):
-    def test_that_duration_field_to_string_should_parse_duration_to_string(self):
+    def test_duration_field_to_string_should_parse_duration_to_string(self):
         self.assertEqual(duration_field_to_string(timedelta(hours=8)), "08:00")
 
 
@@ -37,7 +37,7 @@ class TestExtractionTag:
             ("/kazde/pokolenie/ma/wlasny/2100/1", ["2100", "1"]),
         ],
     )  # pylint: disable=no-self-use
-    def test_that_extract_year_and_month_from_url_function_should_correct_extract_year_and_month(self, url, date):
+    def test_extract_year_and_month_from_url_function_should_correct_extract_year_and_month(self, url, date):
         assert_that(extract_year_and_month_from_url(url)).is_equal_to(date)
 
     @pytest.mark.parametrize(
@@ -48,7 +48,7 @@ class TestExtractionTag:
             "/kazde/pokolenie/ma/2100/1/wlasny",
         ],
     )  # pylint: disable=no-self-use
-    def test_that_if_function_get_incorrect_url_should_return_current_year_and_month(self, url):
+    def test_if_function_get_incorrect_url_should_return_current_year_and_month(self, url):
         assert_that(extract_year_and_month_from_url(url)).is_equal_to(
             [datetime.datetime.now().year, datetime.datetime.now().month]
         )

--- a/managers/tests/test_unit_model.py
+++ b/managers/tests/test_unit_model.py
@@ -14,19 +14,19 @@ from utils.base_tests import BaseModelTestCase
 
 
 class TestProjectModel(TestCase):
-    def test_that_project_should_have_start_date(self):
+    def test_project_should_have_start_date(self):
         project = Project(name="X")
         with self.assertRaises(ValidationError) as exception:
             project.full_clean()
         self.assertTrue("This field cannot be null." in str(exception.exception))
 
-    def test_that_project_name_should_not_be_blank(self):
+    def test_project_name_should_not_be_blank(self):
         project = Project(start_date=datetime.now().date())
         with self.assertRaises(ValidationError) as exception:
             project.full_clean()
         self.assertTrue("This field cannot be blank." in str(exception.exception))
 
-    def test_that_project_name_should_not_be_longer_than_set_max_length(self):
+    def test_project_name_should_not_be_longer_than_set_max_length(self):
         project = Project(start_date=datetime.now().date(), name="X" * (MAX_NAME_LENGTH + 1))
         with self.assertRaises(ValidationError) as exception:
             project.full_clean()
@@ -34,7 +34,7 @@ class TestProjectModel(TestCase):
             "Ensure this value has at most " + str(MAX_NAME_LENGTH) + " characters" in str(exception.exception)
         )  # pylint: disable=line-too-long # noqa E501
 
-    def test_that_project_name_should_be_shorter_than_or_equal_set_max_length(self):
+    def test_project_name_should_be_shorter_than_or_equal_set_max_length(self):
         project = Project(start_date=datetime.now().date(), name="X" * MAX_NAME_LENGTH)
         try:
             project.full_clean()

--- a/users/tests/test_unit_customuser_model.py
+++ b/users/tests/test_unit_customuser_model.py
@@ -16,12 +16,12 @@ from utils.base_tests import BaseModelTestCase
 
 
 class TestCustomUserModel(TestCase):
-    def test_that_create_user_method_should_raise_custom_validation_error_when_email_is_none(self):
+    def test_create_user_method_should_raise_custom_validation_error_when_email_is_none(self):
         with self.assertRaises(ValidationError) as custom_exception:
             CustomUser.objects._create_user(None, "testuserpasswd", False, False, CustomUser.UserType.EMPLOYEE.name)
         self.assertEqual(ValidationErrorText.VALIDATION_ERROR_EMAIL_MESSAGE, custom_exception.exception.message)
 
-    def test_that_create_user_method_should_raise_custom_validation_error_when_password_is_none(self):
+    def test_create_user_method_should_raise_custom_validation_error_when_password_is_none(self):
         with self.assertRaises(ValidationError) as custom_exception:
             CustomUser.objects._create_user(
                 "testuser@codepoets.it", None, False, False, CustomUser.UserType.EMPLOYEE.name
@@ -91,19 +91,19 @@ class TestCustomUserModelMethods(TestCase):
             "testuser@codepoets.it", "testusername", "testuserlastname", "", "testuserpasswd"
         )
 
-    def test_that_get_absolute_url_method_should_return_absolute_url_with_users_email(self):
+    def test_get_absolute_url_method_should_return_absolute_url_with_users_email(self):
         stored_user = CustomUser.objects.get(email=self.user.email)
         self.assertEqual(stored_user.get_absolute_url(), f"/users/{self.user.email}/")
 
-    def test_that_get_full_name_method_should_return_first_and_last_user_name_with_space_between(self):
+    def test_get_full_name_method_should_return_first_and_last_user_name_with_space_between(self):
         stored_user = CustomUser.objects.get(email=self.user.email)
         self.assertEqual(stored_user.get_full_name(), f"{stored_user.first_name} {stored_user.last_name}")
 
-    def test_that_get_short_name_method_should_return_user_first_name(self):
+    def test_get_short_name_method_should_return_user_first_name(self):
         stored_user = CustomUser.objects.get(email=self.user.email)
         self.assertEqual(stored_user.get_short_name(), stored_user.first_name)
 
-    def test_that_email_user_should_send_email_to_self_user(self):
+    def test_email_user_should_send_email_to_self_user(self):
         stored_user = CustomUser.objects.get(email=self.user.email)
         with mock.patch("users.models.CustomUser.email_user") as mocked_method:
             stored_user.email_user(

--- a/users/tests/test_unit_template_tags.py
+++ b/users/tests/test_unit_template_tags.py
@@ -12,12 +12,12 @@ class TestUrlFilterTag:
         ("whole_string", "test_value"),
         [(simply_string, simply_string[:4]), (simply_string, simply_string[:8]), (simply_string, simply_string)],
     )  # pylint: disable=no-self-use
-    def test_that_correct_value_always_return_true(self, whole_string, test_value):
+    def test_correct_value_always_return_true(self, whole_string, test_value):
         assertpy.assert_that(startswith(whole_string, test_value)).is_equal_to(True)
 
     @pytest.mark.parametrize(
         ("whole_string", "test_value"),
         [(simply_string, simply_string[4:]), (simply_string, simply_string[8:]), (simply_string, "")],
     )  # pylint: disable=no-self-use
-    def test_that_incorrect_value_always_return_false(self, whole_string, test_value):
+    def test_incorrect_value_always_return_false(self, whole_string, test_value):
         assertpy.assert_that(startswith(whole_string, test_value)).is_equal_to(False)

--- a/users/tests/test_unit_validators.py
+++ b/users/tests/test_unit_validators.py
@@ -14,26 +14,26 @@ class TestUserAgeValidator(TestCase):
             UserAgeValidator.MINIMAL_ACCETABLE_AGLE, UserAgeValidator.MAXIMAL_ACCEPTABLE_AGE
         )
 
-    def test_that_users_age_can_be_none(self):
+    def test_users_age_can_be_none(self):
         self._assert_date_of_birth_is_valid(None)
 
-    def test_that_users_age_can_be_equal_to_lower_limit(self):
+    def test_users_age_can_be_equal_to_lower_limit(self):
         # user is exactly 18 years old
         date_of_birth = datetime.datetime.strptime("2001-05-27", "%Y-%m-%d").date()
         self._assert_date_of_birth_is_valid(date_of_birth)
 
-    def test_that_users_age_can_be_equal_to_upper_limit(self):
+    def test_users_age_can_be_equal_to_upper_limit(self):
         # user is exactly 100 years old - 1 day (still 99)
         date_of_birth = datetime.datetime.strptime("1919-05-28", "%Y-%m-%d").date()
         self._assert_date_of_birth_is_valid(date_of_birth)
 
-    def test_that_when_users_age_is_below_lower_limit_validation_error_is_raised(self):
+    def test_when_users_age_is_below_lower_limit_validation_error_is_raised(self):
         # user is exactly 18 years old - 1 day (still 17)
         date_of_birth = datetime.datetime.strptime("2001-05-28", "%Y-%m-%d").date()
         with self.assertRaises(ValidationError):
             self.user_age_validator(date_of_birth)
 
-    def test_that_when_users_age_is_above_upper_limit_validation_error_is_raised(self):
+    def test_when_users_age_is_above_upper_limit_validation_error_is_raised(self):
         # user is exactly 100 years old
         date_of_birth = datetime.datetime.strptime("1919-05-27", "%Y-%m-%d").date()
         with self.assertRaises(ValidationError):

--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -240,7 +240,7 @@ class SignUpTests(TestCase):
         self.assertEqual(CustomUser.objects.all().count(), 1)
         self.assertEqual(CustomUser.objects.get(email=self.user.email).is_active, False)
 
-    def test_that_registered_user_must_activate_account_by_activation_link(self):
+    def test_registered_user_must_activate_account_by_activation_link(self):
         with freeze_time("2019-06-07 07:07:07"):
             self.assertEqual(CustomUser.objects.all().count(), 0)
             response = self._register_user_using_signup_view()
@@ -255,7 +255,7 @@ class SignUpTests(TestCase):
             self.assertEqual(response.status_code, 200)
             self.assertEqual(CustomUser.objects.get(email=self.user.email).is_active, True)
 
-    def test_that_registered_user_with_wrong_activation_link_will_not_activate_account(self):
+    def test_registered_user_with_wrong_activation_link_will_not_activate_account(self):
         with freeze_time("2019-06-07 07:07:07"):
             self.assertEqual(CustomUser.objects.all().count(), 0)
             response = self._register_user_using_signup_view()

--- a/utils/tests/test_access_permissions.py
+++ b/utils/tests/test_access_permissions.py
@@ -12,7 +12,7 @@ class AccessPermissionsTestCase(TestCase):
         self.report = ReportFactory()
         self.user = UserFactory()
 
-    def test_that_sending_request_to_view_should_be_allowed_only_for_defined_user_types(self):
+    def test_sending_request_to_view_should_be_allowed_only_for_defined_user_types(self):
         urls_to_allowed_user_types = {
             # Employees.
             reverse("custom-report-list", kwargs={"year": 2019, "month": 5}): [

--- a/utils/tests/test_mixins.py
+++ b/utils/tests/test_mixins.py
@@ -23,7 +23,7 @@ class UserIsAuthorOfCurrentReportMixinTestCase(TestCase):
         self.view = TestView.as_view()
         self.request_factory = RequestFactory()
 
-    def test_that_user_is_author_of_current_report_mixin_should_limit_view_report_queryset_if_user_is_employee(self):
+    def test_user_is_author_of_current_report_mixin_should_limit_view_report_queryset_if_user_is_employee(self):
         user = UserFactory(user_type=CustomUser.UserType.EMPLOYEE.name)
 
         author_report = ReportFactory(author=user)
@@ -39,9 +39,7 @@ class UserIsAuthorOfCurrentReportMixinTestCase(TestCase):
         self.assertEqual(len(response.context_data["object_list"]), 1)
         self.assertEqual(response.context_data["object_list"][0].pk, author_report.pk)
 
-    def test_that_user_is_author_of_current_report_mixin_should_not_limit_view_report_queryset_if_user_is_not_employee(
-        self
-    ):
+    def test_user_is_author_of_current_report_mixin_should_not_limit_view_report_queryset_if_user_is_not_employee(self):
         user = UserFactory(user_type=CustomUser.UserType.MANAGER.name)
 
         ReportFactory(author=user)
@@ -67,7 +65,7 @@ class UserIsManagerOfCurrentProjectMixinTestCase(TestCase):
         self.view = TestView.as_view()
         self.request_factory = RequestFactory()
 
-    def test_that_user_is_manager_of_current_project_mixin_should_limit_view_project_queryset_if_user_is_manager(self):
+    def test_user_is_manager_of_current_project_mixin_should_limit_view_project_queryset_if_user_is_manager(self):
         user = UserFactory(user_type=CustomUser.UserType.MANAGER.name)
 
         manager_project = ProjectFactory()
@@ -84,7 +82,7 @@ class UserIsManagerOfCurrentProjectMixinTestCase(TestCase):
         self.assertEqual(len(response.context_data["object_list"]), 1)
         self.assertEqual(response.context_data["object_list"][0].pk, manager_project.pk)
 
-    def test_that_user_is_manager_of_current_project_mixin_should_not_limit_view_project_queryset_if_user_is_not_manager(
+    def test_user_is_manager_of_current_project_mixin_should_not_limit_view_project_queryset_if_user_is_not_manager(
         self
     ):
         user = UserFactory(user_type=CustomUser.UserType.EMPLOYEE.name)
@@ -113,7 +111,7 @@ class UserIsManagerOfCurrentReportProjectOrAuthorOfCurrentReportMixinTestCase(Te
         self.view = TestView.as_view()
         self.request_factory = RequestFactory()
 
-    def test_that_user_is_manager_of_current_project_or_author_of_current_report_mixin_should_limit_view_project_queryset_if_user_is_manager(
+    def test_user_is_manager_of_current_project_or_author_of_current_report_mixin_should_limit_view_project_queryset_if_user_is_manager(
         self
     ):
         user = UserFactory(user_type=CustomUser.UserType.MANAGER.name)
@@ -132,7 +130,7 @@ class UserIsManagerOfCurrentReportProjectOrAuthorOfCurrentReportMixinTestCase(Te
         self.assertEqual(len(response.context_data["object_list"]), 1)
         self.assertEqual(response.context_data["object_list"][0].pk, report.pk)
 
-    def test_that_user_is_manager_of_current_project_or_author_of_current_report_mixin_should_not_limit_view_project_queryset_if_user_is_not_manager(
+    def test_user_is_manager_of_current_project_or_author_of_current_report_mixin_should_not_limit_view_project_queryset_if_user_is_not_manager(
         self
     ):
         user = UserFactory(user_type=CustomUser.UserType.EMPLOYEE.name)


### PR DESCRIPTION
Resolves https://github.com/Code-Poets/sheetstorm/issues/73