### PR TITLE
Variable default date value on report creation

### DIFF
--- a/employees/views.py
+++ b/employees/views.py
@@ -155,9 +155,23 @@ class ReportListCreateProjectJoinView(MonthNavigationMixin, ProjectsWorkPercenta
     url_name = "custom-report-list"
     object = None
 
+    def _get_default_date(self) -> datetime.date:
+        year = int(self.kwargs["year"])
+        month = int(self.kwargs["month"])
+        queryset = self.get_queryset()
+        if not queryset.exists():
+            return datetime.date(year=year, month=month, day=1)
+        last_report = queryset.first()
+        if last_report.creation_date.date() == timezone.now().date():
+            return last_report.date
+        date = last_report.date + timezone.timedelta(days=1)
+        if date.month != month:
+            return last_report.date
+        return date
+
     def get_initial(self) -> dict:
         initial = super().get_initial()
-        initial.update({"date": timezone.now(), "author": self.request.user})
+        initial.update({"date": self._get_default_date(), "author": self.request.user})
         return initial
 
     def get_queryset(self) -> QuerySet:


### PR DESCRIPTION
Resolves #366 

Added method for deriving default date value in report creation form. This is how it works:
1. If the month is current, then the value is current day.
2. If there are no reports on this month, the value is the first day of the month.
3. If there are reports on this month, the value is the next day from the most recent report.
4. If the most recent report is from the last day of the month, the value is also the last day of the month.

This can be useful if the user is late on filling reports. The date on previous months defaults to the day after the last report (if possible), so after each post the default date value is raised by one day.

Done:
- Added method for calculating appropriate default date for selected month, based on existing reports.