### PR TITLE
Fill context on invalid form response

### DIFF
--- a/employees/views.py
+++ b/employees/views.py
@@ -218,7 +218,7 @@ class ReportListCreateProjectJoinView(MonthNavigationMixin, ProjectsWorkPercenta
             logger.debug(f"User with id: {request.user.pk} join to the project with id: {project.pk}")
             return redirect(self.get_success_url())
         else:
-            return self.render_to_response(context={"form": form})
+            return self.render_to_response(context=self.get_context_data().update({"project_form": form}))
 
 
 class ReportDetailBase(UpdateView):


### PR DESCRIPTION
On project joining in report list view, when the form is invalid the response is `render_to_response`.
The problem is, the provided context is insufficient and also the joining feature `project_form` replaces the report's `form`.
This causes an error in `test_custom_report_list_view_should_handle_no_project_being_selected_in_project_form_on_post` unit test at branch `feature-rebuild-user-reports-interface`, because during render the template refers to non-existing fields (since the forms are switched).

**NOTE:** This is not something that can be experienced via the regular use of Sheet Storm. This use case is merely an extra safety measure to prevent app from crashing on post with insufficient form data. Normally this is impossible.