### PR TITLE
Remove `django-allauth` leftovers

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -11,7 +11,6 @@ Click==7.0
 coverage==4.5.3
 defusedxml==0.6.0
 Django==2.2.2
-django-allauth==0.39.1
 django-bootstrap-datepicker-plus==3.0.5
 django-countries==5.3.3
 django-crispy-forms==1.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ certifi
 chardet
 defusedxml
 Django
-django-allauth
 django-bootstrap-datepicker-plus
 django-countries
 django-crispy-forms

--- a/sheetstorm/settings/base.py
+++ b/sheetstorm/settings/base.py
@@ -44,9 +44,6 @@ INSTALLED_APPS = [
     'django_countries',
     'users',
     # 3rd party
-    'allauth',
-    'allauth.account',
-    'allauth.socialaccount',
     'bootstrap_datepicker_plus',
     'captcha',
     'crispy_forms',


### PR DESCRIPTION
No issue for this, just cleaning usage big library that we don't use now at all.