### PR TITLE
Fix urls namespace and add reverse to missing usages in tests

### DIFF
--- a/sheetstorm/urls.py
+++ b/sheetstorm/urls.py
@@ -16,8 +16,7 @@ from django.urls import include
 
 urlpatterns = [
     url(r"^admin/", admin.site.urls),
-    url(r"^", include("users.urls")),
+    url(r"^employees/", include("employees.urls")),
     url(r"^managers/", include("managers.urls")),
-    url(r"^", include("employees.urls")),
-    # url(r"^select2/", include("django_select2.urls")),
+    url(r"^users/", include("users.urls")),
 ]

--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -113,7 +113,7 @@ class UserCreateTests(TestCase):
             },
         )
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, "/users/")
+        self.assertEqual(response.url, reverse("custom-users-list"))
         self.assertEqual(CustomUser.objects.all().count(), 2)
 
     def test_user_create_view_should_not_add_new_user_on_post_if_form_is_invalid(self):


### PR DESCRIPTION
While cleaning up I have seen that we are still using the same url namespace for two Django apps. This should be avoided if not needed, so I have added the fix. Due to this I have discovered there were some places in which we were using hardcoded urls, so I have switched them to use `reverse`.