### PR TITLE
Bugfix custom report list

### DIFF
--- a/employees/tests/test_views.py
+++ b/employees/tests/test_views.py
@@ -149,6 +149,13 @@ class ReportCustomListTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, other_report.description)
 
+    def test_custom_list_view_should_not_display_other_users_reports_when_user_does_not_have_reports(self):
+        user_with_no_reports = UserFactory()
+        self.client.force_login(user_with_no_reports)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, self.report)
+
     def test_custom_report_list_view_should_add_new_report_on_post(self):
         response = self.client.post(self.url, self.data)
         self.assertEqual(response.status_code, 302)

--- a/employees/views.py
+++ b/employees/views.py
@@ -194,7 +194,7 @@ class ReportListCreateProjectJoinView(MonthNavigationMixin, ProjectsWorkPercenta
         return (
             super()
             .get_queryset()
-            .get_reports_from_a_particular_month(self.kwargs["year"], self.kwargs["month"])
+            .get_reports_from_a_particular_month(self.kwargs["year"], self.kwargs["month"], self.request.user)
             .order_by("-date", "project__name", "-creation_date")
         )
 


### PR DESCRIPTION
Resolves: https://github.com/Code-Poets/sheetstorm/issues/445
I had an error after clean database, when I wanted to get to my reports I had an Attribute error, I wasn't sure why but on debugging I found that queryset returned some reports. I found that add this filter resolve the problem.