### PR TITLE
Bugfix add task activities to Report in initial data

### DIFF
--- a/load_initial_data.sh
+++ b/load_initial_data.sh
@@ -1,2 +1,3 @@
+#!/usr/bin/env bash
 python manage.py loaddata employees/fixtures/task_activities.yaml
 python manage.py load_initial_data

--- a/users/management/commands/load_initial_data.py
+++ b/users/management/commands/load_initial_data.py
@@ -4,6 +4,7 @@ from django.db import transaction
 from django.utils import timezone
 
 from employees.factories import ReportFactory
+from employees.models import TaskActivityType
 from managers.factories import ProjectFactory
 from managers.models import Project
 from users.factories import UserFactory
@@ -128,6 +129,15 @@ class Command(BaseCommand):
         self._add_member_to_project_if_not_added_yet(project_suspended, user_manager_2)
 
         #
+        # Task activities
+        #
+
+        task_activity_review, _ = TaskActivityType.objects.get_or_create(name="Review")
+        task_activity_backend_development, _ = TaskActivityType.objects.get_or_create(name="Backend Development")
+        task_activity_frontend_development, _ = TaskActivityType.objects.get_or_create(name="Frontend Development")
+        task_activity_meeting, _ = TaskActivityType.objects.get_or_create(name="Meeting")
+
+        #
         # Reports
         #
 
@@ -138,6 +148,7 @@ class Command(BaseCommand):
             project=project_pending,
             work_hours=timezone.timedelta(hours=8),
             editable=True,
+            task_activities=task_activity_review,
         )
 
         ReportFactory(
@@ -147,6 +158,7 @@ class Command(BaseCommand):
             project=project_pending,
             work_hours=timezone.timedelta(hours=4),
             editable=True,
+            task_activities=task_activity_review,
         )
 
         ReportFactory(
@@ -156,6 +168,7 @@ class Command(BaseCommand):
             project=project_stopped,
             work_hours=timezone.timedelta(hours=4),
             editable=True,
+            task_activities=task_activity_review,
         )
 
         ReportFactory(
@@ -165,6 +178,7 @@ class Command(BaseCommand):
             project=project_pending,
             work_hours=timezone.timedelta(hours=6),
             editable=True,
+            task_activities=task_activity_review,
         )
 
         ReportFactory(
@@ -174,6 +188,7 @@ class Command(BaseCommand):
             project=project_suspended,
             work_hours=timezone.timedelta(hours=8, minutes=30),
             editable=True,
+            task_activities=task_activity_backend_development,
         )
 
         ReportFactory(
@@ -183,6 +198,7 @@ class Command(BaseCommand):
             project=project_pending,
             work_hours=timezone.timedelta(hours=7, minutes=59),
             editable=True,
+            task_activities=task_activity_backend_development,
         )
 
         ReportFactory(
@@ -192,6 +208,7 @@ class Command(BaseCommand):
             project=project_pending,
             work_hours=timezone.timedelta(hours=2),
             editable=True,
+            task_activities=task_activity_backend_development,
         )
 
         ReportFactory(
@@ -201,6 +218,7 @@ class Command(BaseCommand):
             project=project_stopped,
             work_hours=timezone.timedelta(hours=7, minutes=1),
             editable=True,
+            task_activities=task_activity_frontend_development,
         )
 
         ReportFactory(
@@ -210,6 +228,7 @@ class Command(BaseCommand):
             project=project_suspended,
             work_hours=timezone.timedelta(hours=8),
             editable=True,
+            task_activities=task_activity_frontend_development,
         )
 
         ReportFactory(
@@ -219,6 +238,7 @@ class Command(BaseCommand):
             project=project_stopped,
             work_hours=timezone.timedelta(hours=2),
             editable=True,
+            task_activities=task_activity_frontend_development,
         )
 
         ReportFactory(
@@ -228,6 +248,7 @@ class Command(BaseCommand):
             project=project_suspended,
             work_hours=timezone.timedelta(hours=4),
             editable=True,
+            task_activities=task_activity_meeting,
         )
 
         ReportFactory(
@@ -237,6 +258,7 @@ class Command(BaseCommand):
             project=project_suspended,
             work_hours=timezone.timedelta(hours=8),
             editable=True,
+            task_activities=task_activity_meeting,
         )
 
     @staticmethod


### PR DESCRIPTION
Resolves: https://github.com/Code-Poets/sheetstorm/issues/449

When we create reports in initial data we didn't pass task activities, due to this `TaskActivityTypeFactory` was creating new task activity object from this values `"Review", "Backend Development", "Frontend Development", "Meeting"`