### PR TITLE
Bugfix add freeze_time decorator to work percentage time mixin tests

### DIFF
--- a/utils/tests/test_mixins.py
+++ b/utils/tests/test_mixins.py
@@ -2,6 +2,7 @@ from django.test import RequestFactory
 from django.test import TestCase
 from django.utils import timezone
 from django.views.generic import ListView
+from freezegun import freeze_time
 from mock import patch
 
 from employees.factories import ReportFactory
@@ -152,6 +153,7 @@ class UserIsManagerOfCurrentReportProjectOrAuthorOfCurrentReportMixinTestCase(Te
         self.assertEqual(len(response.context_data["object_list"]), 2)
 
 
+@freeze_time("2019-11-06 21:00:00")
 class ProjectsWorkPercentageMixinTestCase(TestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
There is no issue for that. Problem occurred because today is last day in month and in tests was hard-coded November and as we all know November has 30 days:)