### PR TITLE
Feature add dynamic filter for task activities per project

### DIFF
--- a/employees/common/strings.py
+++ b/employees/common/strings.py
@@ -106,6 +106,7 @@ class ReportValidationStrings(NotCallableMixin, Enum):
     WORK_HOURS_FIELD_NOT_TIMEDELTA_INSTANCE = _("Work hours field must be instance of timedelta")
     WORK_HOURS_WRONG_FORMAT = _("Acceptable format for work hours field is: HH:MM and HH")
     USER_NOT_IN_PROJECT_MESSAGE = _("You are not a part of this project ")
+    TASK_ACTIVITY_NOT_RELATED_TO_PROJECT = _("Select a valid choice. That choice is not one of the available choices.")
 
 
 class MonthNavigationText(NotCallableMixin, Enum):

--- a/employees/static/employees/scripts/load_activities_for_project.js
+++ b/employees/static/employees/scripts/load_activities_for_project.js
@@ -1,0 +1,13 @@
+$("#id_project").change(function () {
+    var url = $("#reportForm").attr("data-task-activities-url");
+    var projectId = $(this).val();
+    $.ajax({
+        url: url,
+        data: {
+            'project': projectId
+        },
+        success: function (data) {
+            $("#id_task_activities").html(data);
+        }
+    });
+});

--- a/employees/templates/employees/partial/task_activity_list.html
+++ b/employees/templates/employees/partial/task_activity_list.html
@@ -1,0 +1,3 @@
+{% for task_activity in task_activities %}
+    <option value="{{ task_activity.pk }}">{{ task_activity.name }}</option>
+{% endfor %}

--- a/employees/templates/employees/report_list.html
+++ b/employees/templates/employees/report_list.html
@@ -22,7 +22,7 @@
     {% for error in errors.non_field_errors %}
     <h4><font color="red">{{ error }}</font></h4>
     {% endfor %}
-    <form action="{{ path }}" method="POST">
+    <form action="{{ path }}" method="POST" id="reportForm" data-task-activities-url="{% url 'ajax-load-task-activities' %}">
         {% csrf_token %}
         {{ form|crispy }}
        <input type="submit" value="{{ UI_text.CREATE_REPORT_BUTTON.value }}">
@@ -119,4 +119,5 @@
             document.getElementById("join_form").hidden = true;
         </script>
     {% endif %}
+    <script src="{% static 'employees/scripts/load_activities_for_project.js' %}"></script>
 {% endblock %}

--- a/employees/urls.py
+++ b/employees/urls.py
@@ -42,4 +42,9 @@ urlpatterns = [
         views.ExportAuthorReportProjectView.as_view(),
         name="export-project-author-reports",
     ),
+    url(
+        r"^ajax/load-task-activities/",
+        views.LoadTaskActivitiesInProjectView.as_view(),
+        name="ajax-load-task-activities",
+    ),
 ]


### PR DESCRIPTION
Related: https://github.com/Code-Poets/sheetstorm/pull/460

On this branch I added dynamic filter for task activity list per each project.
After approving this PR: https://github.com/Code-Poets/sheetstorm/pull/460 I will start to create a panel admin view for task activities.

After `full_check` you can notice two failed test but It has been reported because it occured on master branch.
