### PR TITLE
Improve coverage settings

### DIFF
--- a/coverage-config
+++ b/coverage-config
@@ -2,11 +2,12 @@
 omit=
 	manage.py
 	*/__init__.py
-    	*/admin.py
-    	*/apps.py
-    	*/urls.py
-    	*/wsgi.py
-    	*/migrations/*
-    	*/mocks/*
-    	*/tests*
-    	*/settings/*
+    */admin.py
+    */apps.py
+    */urls.py
+    */wsgi.py
+    */migrations/*
+    */mocks/*
+    */tests*
+    */settings/*
+    features/*

--- a/e2e.sh
+++ b/e2e.sh
@@ -1,3 +1,5 @@
 #!/bin/bash -e
 
-python manage.py behave --settings=sheetstorm.settings.testing --no-capture
+coverage run --source='.' --rcfile=coverage-config manage.py behave --settings=sheetstorm.settings.testing --no-capture
+coverage report
+rm .coverage

--- a/full-check.sh
+++ b/full-check.sh
@@ -25,6 +25,6 @@ printf "========================= UNIT TESTS WITH COVERAGE =================\n"
 ./run-test-coverage.sh
 printf "\n"
 
-printf "========================= E2E SELENIUM TESTS ======================\n"
+printf "================= E2E SELENIUM TESTS WITH COVERAGE =================\n"
 ./e2e.sh
 printf "\n"


### PR DESCRIPTION
No issue for that.
Long story short - after selenium `e2e` tests had been added, our unit tests coverage dropped significantly (because `features/` folder had been not marked as excluded in `coverage-config`)
This PR:
1. Fixes `coverage-config`
2. Adds coverage report for `e2e` tests

