### PR TITLE
Bugfix disable `cyclic-import` in pylintrc config

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -164,7 +164,8 @@ disable=print-statement,
         line-too-long,
         no-member,
         abstract-method,
-        arguments-differ
+        arguments-differ,
+        cyclic-import,
 
 
 # Enable the message, report, category or checker with the given id(s). You can


### PR DESCRIPTION
There is no issue for this. We have to disable `cyclic-import` becuase of https://github.com/PyCQA/pylint/issues/850