### PR TITLE
Bugfix remove CustomUser model fields from admin panel

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -10,10 +10,7 @@ from users.models import CustomUser
 class CustomUserAdmin(UserAdmin):
     fieldsets = (
         (None, {"fields": ("email", "password")}),
-        (
-            CustomUserAdminText.PERSONAL_INFO,
-            {"fields": ("first_name", "last_name", "date_of_birth", "phone_number", "country")},
-        ),
+        (CustomUserAdminText.PERSONAL_INFO, {"fields": ("first_name", "last_name")}),
         (CustomUserAdminText.STATUS, {"fields": ("user_type",)}),
         (
             CustomUserAdminText.PERMISSIONS,


### PR DESCRIPTION
After removing few CustomUser fields due to RODO, there are some residue left in `users/admin.py`. It causes not working admin site, while trying to edit user:
![error](https://user-images.githubusercontent.com/37015250/64010767-b521f300-cb1a-11e9-8d11-423517f45641.png)
So I only removed these fields from `CustomUser PERSONAL_INFO`