### PR TITLE
Bugfix redirect admin to his own report edition

### DIFF
--- a/employees/templates/employees/partial/display_reports/reports_in_date_for_author.html
+++ b/employees/templates/employees/partial/display_reports/reports_in_date_for_author.html
@@ -1,5 +1,6 @@
 {% load data_display_filters %}
 {% load data_structure_element_selectors %}
+{% url 'custom-report-list' year month as custom_report_list_url %}
 
 {% for reports in date %}
     {% for report in reports.list %}
@@ -18,7 +19,11 @@
     </td>
     <td class="edit-button-column Invisible hidden-print">
         {% if report.editable %}
-            <a href="{% if request.user.is_admin %}{% url 'admin-report-detail' pk=report.id %}{% else %}{% url 'custom-report-detail' pk=report.id %}{% endif %}" class="btn btn-light hidden-print">
+            {% if request.user == report.author %}
+                <a href="{% url 'custom-report-detail' pk=report.id %}" class="btn btn-light hidden-print">
+            {% else %}
+                <a href="{% url 'admin-report-detail' pk=report.id %}" class="btn btn-light hidden-print">
+            {% endif %}
                 <span class="glyphicon glyphicon-edit span-edit-report hidden-print"></span>
             </a>
         {% endif %}


### PR DESCRIPTION
There is no issue fo this.

Fixes:
 - admin now can delete his own report like any other employee
 - after editing own report admin is redirected to "my reports" site