### PR TITLE
Feature improve monthly hours stats

### DIFF
--- a/employees/common/strings.py
+++ b/employees/common/strings.py
@@ -23,8 +23,10 @@ class ReportListStrings(NotCallableMixin, Enum):
     HOURS_PER_MONTH_LABEL = _("Monthly hours")
     EDIT_REPORT_BUTTON = _("Edit")
     NO_PROJECTS_TO_JOIN = _("There are no other projects available.")
-    PROJECTS_WORK_PERCENTAGE_HEADER = _("Projects work percentage")
-    NO_REPORTS_MESSAGE = _("There is no reports to display")
+    NO_REPORTS_MESSAGE = _("There are no reports to display")
+    PROJECTS_WORK_PERCENTAGE_HEADER = _("Monthly work stats per project")
+    HOURS_SUM_HEADER = _("Total hours")
+    HOURS_PERCENTAGE_HEADER = _("Percentage")
 
 
 class ReportDetailStrings(NotCallableMixin, Enum):
@@ -72,7 +74,9 @@ class AuthorReportListStrings(NotCallableMixin, Enum):
     HOURS_PER_MONTH_LABEL = _("Monthly hours")
     NO_REPORTS_MESSAGE = _("This employee has no reports to display.")
     RETURN_BUTTON_MESSAGE = _("Back to employee list")
-    PROJECTS_WORK_PERCENTAGE_HEADER = _("Projects work percentage")
+    PROJECTS_WORK_PERCENTAGE_HEADER = _("Monthly work stats per project")
+    HOURS_SUM_HEADER = _("Total hours")
+    HOURS_PERCENTAGE_HEADER = _("Percentage")
 
 
 class ProjectReportListStrings(NotCallableMixin, Enum):

--- a/employees/static/employees/style.css
+++ b/employees/static/employees/style.css
@@ -17,6 +17,7 @@
 
 .table {
     table-layout: fixed;
+    text-align: left;
 }
 
 .modal-dialog {
@@ -43,25 +44,8 @@
     width: 8.77%;
 }
 
-.date-column {
-    text-align: left;
-}
-
-.project-column {
-    text-align: left;
-}
-
-.task-activities-column {
-    text-align: left;
-}
-
 .description-column {
-    text-align: left;
     word-wrap: break-word;
-}
-
-.work-hours-column {
-    text-align: left;
 }
 
 .edit-button-column {

--- a/employees/templates/employees/partial/projects_work_percentage.html
+++ b/employees/templates/employees/partial/projects_work_percentage.html
@@ -1,10 +1,25 @@
-<h3>{{ UI_text.PROJECTS_WORK_PERCENTAGE_HEADER.value }}</h3>
 <table class="table">
+    <thead>
+        <tr>
+            <td colspan="4">
+                <h4><strong>{{ UI_text.PROJECTS_WORK_PERCENTAGE_HEADER.value }}</strong></h4>
+            </td>
+            <td colspan="5">
+                <hr class="hr-blue-line"/>
+            </td>
+        </tr>
+        <tr>
+            <th class="th-blue-border-first-cell" colspan="5">{{ UI_text.PROJECT_COLUMN_HEADER.value }}</th>
+            <th class="th-blue-border" colspan="2">{{ UI_text.HOURS_SUM_HEADER.value }}</th>
+            <th class="th-blue-border" colspan="2">{{ UI_text.HOURS_PERCENTAGE_HEADER.value }}</th>
+        </tr>
+    </thead>
     <tbody>
         {% for project, work_percentage in projects_work_percentage.items %}
         <tr>
-            <td>{{ project }}</td>
-            <td>{{ work_percentage|floatformat:2 }} %</td>
+            <td colspan="5"><strong>{{ project }}</strong></td>
+            <td colspan="2">{{ work_percentage.0 }}</td>
+            <td colspan="2">{{ work_percentage.1|floatformat:2 }} %</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/employees/tests/test_unit_report_model.py
+++ b/employees/tests/test_unit_report_model.py
@@ -284,7 +284,7 @@ class TestGetProjectsWorkPercentage(TestCase):
         self.project_2 = ProjectFactory()
         self.user.projects.add(self.project_1, self.project_2)
 
-    def test_get_projects_work_percentage_should_return_projects_with_work_time_percent(self):
+    def test_get_projects_work_hours_and_percentage_should_return_projects_with_work_time_percent(self):
         ReportFactory(
             author=self.user, project=self.project_1, work_hours=timezone.timedelta(hours=8), date=timezone.now().date()
         )
@@ -295,12 +295,12 @@ class TestGetProjectsWorkPercentage(TestCase):
             author=self.user, project=self.project_2, work_hours=timezone.timedelta(hours=8), date=timezone.now().date()
         )
 
-        result = self.user.get_projects_work_percentage()
+        result = self.user.get_projects_work_hours_and_percentage()
 
         self.assertEqual(len(result), 2)
-        self.assertEqual(result, {self.project_1: 40.0, self.project_2: 60.0})
+        self.assertEqual(result, {self.project_1: ["8:00", 40.0], self.project_2: ["12:00", 60.0]})
 
-    def test_get_projects_work_percentage_should_return_data_from_current_month_start_to_now_if_no_params_provided(
+    def test_get_projects_work_hours_and_percentage_should_return_data_from_current_month_start_to_now_if_no_params_provided(
         self
     ):
         previous_month = timezone.now().date() - timezone.timedelta(days=31)
@@ -312,12 +312,12 @@ class TestGetProjectsWorkPercentage(TestCase):
         )
         self.user.projects.add(self.project_1, self.project_2)
 
-        result = self.user.get_projects_work_percentage()
+        result = self.user.get_projects_work_hours_and_percentage()
 
         self.assertEqual(len(result), 1)
-        self.assertEqual(result, {self.project_1: 100.0})
+        self.assertEqual(result, {self.project_1: ["8:00", 100.0]})
 
-    def test_get_projects_work_percentage_should_return_data_from_given_time_range_if_params_provided(self):
+    def test_get_projects_work_hours_and_percentage_should_return_data_from_given_time_range_if_params_provided(self):
         ReportFactory(
             author=self.user,
             project=self.project_1,
@@ -328,13 +328,13 @@ class TestGetProjectsWorkPercentage(TestCase):
             author=self.user, project=self.project_2, work_hours=timezone.timedelta(hours=4), date=timezone.now().date()
         )
 
-        result = self.user.get_projects_work_percentage(
+        result = self.user.get_projects_work_hours_and_percentage(
             from_date=timezone.now().date() - timezone.timedelta(days=3),
             to_date=timezone.now().date() - timezone.timedelta(days=1),
         )
 
         self.assertEqual(len(result), 1)
-        self.assertEqual(result, {self.project_1: 100.0})
+        self.assertEqual(result, {self.project_1: ["8:00", 100.0]})
 
 
 class TestGetProjectOrderedByLastReportCreationDate(TestCase):

--- a/utils/mixins.py
+++ b/utils/mixins.py
@@ -53,11 +53,10 @@ class ProjectsWorkPercentageMixin(ContextMixin):
             year = int(self.kwargs["year"])
             month = int(self.kwargs["month"])
             current_date = timezone.now().date()
+            from_date = timezone.datetime(year=year, month=month, day=1).date()
             if current_date.year == year and current_date.month == month:
-                from_date = current_date - timezone.timedelta(days=30)
                 to_date = current_date
             else:
-                from_date = timezone.now().date().replace(year=year, month=month, day=1)
                 to_date = self._set_last_day_of_month_on_date(year=year, month=month)
 
         if self.model == CustomUser:
@@ -65,7 +64,7 @@ class ProjectsWorkPercentageMixin(ContextMixin):
         else:
             user = self.request.user
 
-        context_data["projects_work_percentage"] = user.get_projects_work_percentage(from_date, to_date)
+        context_data["projects_work_percentage"] = user.get_projects_work_hours_and_percentage(from_date, to_date)
         return context_data
 
     @staticmethod

--- a/utils/tests/test_mixins.py
+++ b/utils/tests/test_mixins.py
@@ -167,20 +167,24 @@ class ProjectsWorkPercentageMixinTestCase(TestCase):
         self.request.user = UserFactory()
 
     def test_project_work_percentage_mixin_should_call_get_projects_work_percentage_with_none_parameters(self):
-        with patch("users.models.CustomUser.get_projects_work_percentage") as get_projects_work_percentage:
+        with patch(
+            "users.models.CustomUser.get_projects_work_hours_and_percentage"
+        ) as get_projects_work_hours_and_percentage:
             response = self.view(self.request)
 
         self.assertEqual(response.status_code, 200)
-        get_projects_work_percentage.assert_called_once_with(None, None)
+        get_projects_work_hours_and_percentage.assert_called_once_with(None, None)
 
     def test_project_work_percentage_mixin_should_call_get_projects_work_percentage_with_parameters_if_provided_to_view(
         self
     ):
-        with patch("users.models.CustomUser.get_projects_work_percentage") as get_projects_work_percentage:
+        with patch(
+            "users.models.CustomUser.get_projects_work_hours_and_percentage"
+        ) as get_projects_work_hours_and_percentage:
             response = self.view(self.request, year=2000, month=11)
 
         self.assertEqual(response.status_code, 200)
-        get_projects_work_percentage.assert_called_once_with(
+        get_projects_work_hours_and_percentage.assert_called_once_with(
             timezone.now().date().replace(year=2000, month=11, day=1),
             timezone.now().date().replace(year=2000, month=11, day=30),
         )
@@ -190,20 +194,26 @@ class ProjectsWorkPercentageMixinTestCase(TestCase):
     ):
         current_date = timezone.now().date()
 
-        with patch("users.models.CustomUser.get_projects_work_percentage") as get_projects_work_percentage:
+        with patch(
+            "users.models.CustomUser.get_projects_work_hours_and_percentage"
+        ) as get_projects_work_hours_and_percentage:
             response = self.view(self.request, year=current_date.year, month=current_date.month)
 
         self.assertEqual(response.status_code, 200)
-        get_projects_work_percentage.assert_called_once_with(current_date - timezone.timedelta(days=30), current_date)
+        get_projects_work_hours_and_percentage.assert_called_once_with(
+            timezone.datetime(year=current_date.year, month=current_date.month, day=1).date(), current_date
+        )
 
     @freeze_time("2019-07-31 14:23")
     def test_setting_previous_month_works_with_shorter_months(self):
         june = 6
-        with patch("users.models.CustomUser.get_projects_work_percentage") as get_projects_work_percentage:
+        with patch(
+            "users.models.CustomUser.get_projects_work_hours_and_percentage"
+        ) as get_projects_work_hours_and_percentage:
             response = self.view(self.request, year=2019, month=june)
 
         self.assertEqual(response.status_code, 200)
-        get_projects_work_percentage.assert_called_once_with(
+        get_projects_work_hours_and_percentage.assert_called_once_with(
             timezone.now().date().replace(year=2019, month=june, day=1),
             timezone.now().date().replace(year=2019, month=june, day=30),
         )


### PR DESCRIPTION
The monthly work hours are now always calculated form the beginning of the month.
The information about actual amount of hours spent on project is displayed next to the percentage.