### PR TITLE
Bugfix inactive users are displayed in app

### DIFF
--- a/managers/forms.py
+++ b/managers/forms.py
@@ -14,12 +14,13 @@ class ProjectAdminForm(forms.ModelForm):
         user_pk = kwargs.pop("user_pk", None)
         super().__init__(*args, **kwargs)
 
-        managers_to_choose = CustomUser.objects.exclude(user_type=CustomUser.UserType.EMPLOYEE.name)
+        managers_to_choose = CustomUser.objects.active().exclude(user_type=CustomUser.UserType.EMPLOYEE.name)
         if self.instance.pk:
             self.fields["managers"].queryset = managers_to_choose
         else:
             self.fields["managers"].queryset = managers_to_choose.exclude(pk=user_pk)
             self.fields["managers"].required = False
+        self.fields["members"].queryset = CustomUser.objects.active()
 
     class Meta:
         model = Project
@@ -33,6 +34,10 @@ class ProjectAdminForm(forms.ModelForm):
 
 
 class ProjectManagerForm(forms.ModelForm):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.fields["members"].queryset = CustomUser.objects.active()
+
     class Meta:
         model = Project
         exclude = ("managers",)

--- a/managers/tests/test_views.py
+++ b/managers/tests/test_views.py
@@ -148,6 +148,12 @@ class ProjectCreateViewTests(ProjectBaseTests):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, ProjectCreateView.template_name)
 
+    def test_project_create_view_should_exclude_inactive_users_from_members_field(self):
+        inactive_user = UserFactory(is_active=False)
+        response = self.client.get(self.url)
+        form = response.context_data["form"]
+        self.assertTrue(inactive_user not in form.fields["members"].queryset)
+
     def test_project_create_view_should_add_new_project_on_post_and_add_user_of_request_to_managers(self):
         response = self.client.post(self.url, self.data)
         self.assertEqual(response.status_code, 302)
@@ -188,6 +194,12 @@ class ProjectUpdateViewTestCase(ProjectBaseTests):
     def test_project_update_view_should_return_404_status_code_on_get_if_project_does_not_exist(self):
         response = self.client.get(reverse("custom-project-update", kwargs={"pk": self.project.pk + 1}))
         self.assertEqual(response.status_code, 404)
+
+    def test_project_create_view_should_exclude_inactive_users_from_members_field(self):
+        inactive_user = UserFactory(is_active=False)
+        response = self.client.get(self.url)
+        form = response.context_data["form"]
+        self.assertTrue(inactive_user not in form.fields["members"].queryset)
 
     def test_project_update_view_should_update_project_on_post(self):
         response = self.client.post(self.url, self.data)

--- a/managers/views.py
+++ b/managers/views.py
@@ -115,7 +115,7 @@ class ProjectCreateView(CreateView):
             assert not self.request.user.is_employee
             managers_pk_list = [manager.pk for manager in form.cleaned_data["managers"]]
             managers_pk_list.append(self.request.user.pk)
-            managers_queryset = CustomUser.objects.filter(pk__in=managers_pk_list)
+            managers_queryset = CustomUser.objects.active().filter(pk__in=managers_pk_list)
             form.cleaned_data["managers"] = managers_queryset
         project = form.save()
         logger.info(f"New project with id: {project.pk} has been created")

--- a/users/forms.py
+++ b/users/forms.py
@@ -1,3 +1,6 @@
+from typing import Any
+from typing import Dict
+
 from captcha.fields import CaptchaField
 from captcha.fields import CaptchaTextInput
 from django import forms
@@ -51,6 +54,16 @@ class CustomUserChangeForm(UserChangeForm):
     class Meta:
         model = CustomUser
         fields = "__all__"
+
+    def clean(self) -> Dict[str, Any]:
+        cleaned_data = super().clean()
+        cleaned_is_active = cleaned_data.get("is_active")
+        if self.instance.is_active and not cleaned_is_active:
+            cleaned_data["user_type"] = CustomUser.UserType.EMPLOYEE.name
+            cleaned_data["is_staff"] = False
+            cleaned_data["is_superuser"] = False
+
+        return cleaned_data
 
 
 class CustomUserSignUpForm(UserCreationForm):

--- a/users/tests/test_unit_customuser_model.py
+++ b/users/tests/test_unit_customuser_model.py
@@ -8,6 +8,7 @@ from freezegun import freeze_time
 from users.common.constants import UserConstants
 from users.common.model_helpers import create_user_using_full_clean_and_save
 from users.common.strings import ValidationErrorText
+from users.factories import UserFactory
 from users.models import CustomUser
 from utils.base_tests import BaseModelTestCase
 
@@ -55,6 +56,13 @@ class TestCustomUserModel(TestCase):
                 "testuser@codepoets.it", "", "a" * (UserConstants.LAST_NAME_MAX_LENGTH.value + 1), "newuserpasswd"
             )
         self.assertTrue(str(MaxLengthValidator.message) in str(exception.exception))
+
+    def test_user_queryset_active_method_should_return_queryset_of_only_active_users(self):
+        active_user = UserFactory()
+        inactive_user = UserFactory(is_active=False)
+        queryset = CustomUser.objects.active()
+        self.assertTrue(active_user in queryset)
+        self.assertFalse(inactive_user in queryset)
 
 
 class TestCustomUserModelMethods(TestCase):

--- a/users/tests/test_unit_customuser_signals.py
+++ b/users/tests/test_unit_customuser_signals.py
@@ -4,14 +4,13 @@ from django.utils import timezone
 
 from managers.models import Project
 from users.factories import AdminUserFactory
+from users.factories import ManagerUserFactory
 from users.models import CustomUser
 
 
 class TestCustomUserSignals(TestCase):
     def setUp(self):
-        self.user = CustomUser(
-            email="testuser@codepoets.it", password="newuserpasswd", user_type=CustomUser.UserType.MANAGER.name
-        )
+        self.user = ManagerUserFactory()
         self.user.full_clean()
         self.user.save()
         self.user_admin = AdminUserFactory()
@@ -19,13 +18,14 @@ class TestCustomUserSignals(TestCase):
         self.project = Project(name="TEST", start_date=timezone.now())
         self.project.save()
         self.project.managers.add(self.user)
+        self.project.members.add(self.user)
 
     def test_user_should_not_be_in_project_as_manager_when_he_is_no_longer_manager(self):
         response = self.client.post(
             path=reverse("custom-user-update-by-admin", args=(self.user.pk,)),
             data={
-                "email": "testuser@codepoets.it",
-                "password": "newuserpasswd",
+                "email": self.user.email,
+                "password": self.user.password,
                 "user_type": CustomUser.UserType.EMPLOYEE.name,
             },
         )
@@ -33,3 +33,20 @@ class TestCustomUserSignals(TestCase):
         self.user.refresh_from_db()
         self.assertEqual(self.user.user_type, CustomUser.UserType.EMPLOYEE.name)
         self.assertFalse(self.project in self.user.manager_projects.all())
+
+    def test_user_should_not_be_a_project_member_when_he_is_no_longer_active(self):
+        superuser = AdminUserFactory(is_staff=True, is_superuser=True)
+        self.client.force_login(superuser)
+        response = self.client.post(
+            path=f"/admin/users/customuser/{self.user.pk}/change/",
+            data={
+                "email": self.user.email,
+                "password": self.user.password,
+                "user_type": self.user.user_type,
+                "is_active": False,
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.user_type, CustomUser.UserType.EMPLOYEE.name)
+        self.assertFalse(self.project in self.user.projects.all())

--- a/users/views.py
+++ b/users/views.py
@@ -144,7 +144,7 @@ class UserUpdateByAdmin(UpdateView):
 class UserList(ListView):
     template_name = "users_list.html"
     model = CustomUser
-    queryset = CustomUser.objects.prefetch_related("projects")
+    queryset = CustomUser.objects.active().prefetch_related("projects")
 
     def get_context_data(self, *, _object_list: Any = None, **kwargs: Any) -> dict:
         context_data = super().get_context_data(**kwargs)


### PR DESCRIPTION
Fixes multiple issues regarding deactivating users by marking them as inactive using the _is_active_ field in _**CustomUser**_ model.

Now after deactivating a user through the admin panel, the following will happen:

- The user won't be listed on the employees' list anymore

- His user type will be changed to an employee and all of his privileges will be disabled

- The user will be removed from all projects as both member and a manager

- All of his reports will remain intact and will be displayed for his former projects

- It will be impossible to pick this user as a member or manager during project creation and editing

It is also confirmed that deactivation results in disabling notifications regarding the user and an appropriate unit test has been added.